### PR TITLE
Add SimpleWindowEvent type for easier matching on window events

### DIFF
--- a/examples/loop_mode.rs
+++ b/examples/loop_mode.rs
@@ -1,6 +1,7 @@
 extern crate nannou;
 
-use nannou::{App, Event, Frame, LoopMode, WindowEvent, ElementState};
+use nannou::{App, Event, Frame, LoopMode};
+use nannou::event::SimpleWindowEvent::*;
 
 fn main() {
     nannou::run(model, update, draw);
@@ -18,21 +19,16 @@ fn model(app: &App) -> Model {
 }
 
 fn update(app: &App, model: Model, event: Event) -> Model {
+    println!("{:?}", event);
     match event {
-        Event::WindowEvent(_id, event) => {
-            println!("{:?}", event);
-            // If any key was pressed, switch loop mode.
-            if let WindowEvent::KeyboardInput { input, .. } = event {
-                if let (ElementState::Pressed, Some(_)) = (input.state, input.virtual_keycode) {
-                    match app.loop_mode() {
-                        LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
-                        LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
-                    }
-                }
-            }
+        Event::WindowEvent(_id, event) => match event.simple {
+            KeyPressed(_) => match app.loop_mode() {
+                LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
+                LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
+            },
+            _ => (),
         },
-        Event::Update(update) => {
-            println!("{:?}", &update);
+        Event::Update(_update) => {
         },
         _ => (),
     }

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -24,7 +24,7 @@ fn update(_app: &App, model: Model, event: Event) -> Model {
     match event {
         // Handle window events like mouse, keyboard, resize, etc here.
         Event::WindowEvent(id, event) => {
-            println!("Window {:?}: {:?}", id, event);
+            println!("Window {:?}: {:?}", id, event.simple);
         },
         // `Update` the model here.
         Event::Update(_update) => {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -19,7 +19,7 @@ fn update(_app: &App, model: Model, event: Event) -> Model {
     match event {
         // Handle window events like mouse, keyboard, resize, etc here.
         Event::WindowEvent(_id, event) => {
-            println!("{:?}", event);
+            println!("{:?}", event.simple);
         },
         // `Update` the model here.
         Event::Update(_update) => {

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -1,8 +1,8 @@
 extern crate nannou;
 
-use nannou::{App, Frame};
-use nannou::event::{ElementState, Event, Update, WindowEvent};
+use nannou::{App, Event, Frame};
 use nannou::window;
+use nannou::event::SimpleWindowEvent::*;
 
 fn main() {
     nannou::run(model, event, view);
@@ -10,7 +10,6 @@ fn main() {
 
 struct Model {
     window: window::Id,
-    // Add the state of your application here.
 }
 
 fn model(app: &App) -> Model {
@@ -18,44 +17,48 @@ fn model(app: &App) -> Model {
     Model { window }
 }
 
-fn event(app: &App, model: Model, event: Event) -> Model {
+fn event(_app: &App, model: Model, event: Event) -> Model {
     match event {
-        Event::WindowEvent(id, event) => window_event(app, model, id, event),
-        Event::Update(dt) => update(app, model, dt),
-        _ => model,
-    }
-}
+        Event::WindowEvent(_id, event) => match event.simple {
 
-fn window_event(_app: &App, model: Model, _window_id: window::Id, event: WindowEvent) -> Model {
-    match event {
-        WindowEvent::KeyboardInput { input, .. } => match input.virtual_keycode {
-            Some(_key) => match input.state {
-                ElementState::Pressed => {
-                    // Handle key presses.
-                },
-                ElementState::Released => {
-                    // Handle key releases.
-                },
+            Moved(_pos) => {
             },
-            _ => (),
-        },
-        WindowEvent::MouseInput { state, button, .. } => match state {
-            ElementState::Pressed => {
-                // Handle mouse presses.
+
+            KeyPressed(_key) => {
             },
-            ElementState::Released => {
-                // Handle mouse releases.
+
+            KeyReleased(_key) => {
             },
+
+            MouseMoved(_pos) => {
+            },
+
+            MouseDragged(_pos, _button) => {
+            },
+
+            MousePressed(_button) => {
+            },
+
+            MouseReleased(_button) => {
+            },
+
+            MouseEntered => {
+            },
+
+            MouseExited => {
+            },
+
+            Resized(_size) => {
+            },
+
+            _other => (),
         },
-        WindowEvent::MouseMoved { position, .. } => {
-            // Handle mouse movement.
+
+        Event::Update(_dt) => {
         },
+
         _ => (),
     }
-    model
-}
-
-fn update(_app: &App, model: Model, _update: Update) -> Model {
     model
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use window;
 /// - all OpenGL windows (for graphics and user input, can be referenced via IDs).
 pub struct App {
     pub(super) events_loop: glutin::EventsLoop,
-    pub(super) displays: RefCell<HashMap<window::Id, glium::Display>>,
+    pub(crate) displays: RefCell<HashMap<window::Id, glium::Display>>,
     pub(super) exit_on_escape: Cell<bool>,
     loop_mode: Cell<LoopMode>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ fn run_loop<M, E>(mut app: App, mut model: M, update_fn: UpdateFn<M, E>, draw_fn
         glutin_event: glutin::Event,
     ) -> (M, bool)
     where
-        E: From<glutin::Event>,
+        E: LoopEvent,
     {
         // Inspect the event to see if it would require closing the App.
         let mut exit_on_escape = false;
@@ -98,7 +98,8 @@ fn run_loop<M, E>(mut app: App, mut model: M, update_fn: UpdateFn<M, E>, draw_fn
             }
         }
 
-        model = update_fn(&app, model, glutin_event.into());
+        let event = E::from_glutin_event(glutin_event, app);
+        model = update_fn(&app, model, event);
 
         // If exit on escape was triggered, we're done.
         let exit = if exit_on_escape || app.displays.borrow().is_empty() {


### PR DESCRIPTION
This addresses and closes #5.

The examples have been updated and currently do a glob import e.g.

```rust
use nannou::event::SimpleWindowEvent::*;
```

However this will probably get removed soon in favour of adding these
variants to the prelude (see #10).