### PR TITLE
Add a prelude module to remove common boilerplate from projects

### DIFF
--- a/examples/loop_mode.rs
+++ b/examples/loop_mode.rs
@@ -1,14 +1,13 @@
 extern crate nannou;
 
-use nannou::{App, Event, Frame, LoopMode};
-use nannou::event::SimpleWindowEvent::*;
+use nannou::prelude::*;
 
 fn main() {
     nannou::run(model, update, draw);
 }
 
 struct Model {
-    window: nannou::window::Id,
+    window: WindowId,
 }
 
 fn model(app: &App) -> Model {

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -1,16 +1,15 @@
 extern crate nannou;
 
-use nannou::{App, Event, Frame};
-use nannou::window;
+use nannou::prelude::*;
 
 fn main() {
     nannou::run(model, update, draw);
 }
 
 struct Model {
-    a: window::Id,
-    b: window::Id,
-    c: window::Id,
+    a: WindowId,
+    b: WindowId,
+    c: WindowId,
 }
 
 fn model(app: &App) -> Model {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -1,13 +1,13 @@
 extern crate nannou;
 
-use nannou::{App, Event, Frame};
+use nannou::prelude::*;
 
 fn main() {
     nannou::run(model, update, draw);
 }
 
 struct Model {
-    window: nannou::window::Id,
+    window: WindowId,
 }
 
 fn model(app: &App) -> Model {

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -1,15 +1,13 @@
 extern crate nannou;
 
-use nannou::{App, Event, Frame};
-use nannou::window;
-use nannou::event::SimpleWindowEvent::*;
+use nannou::prelude::*;
 
 fn main() {
     nannou::run(model, event, view);
 }
 
 struct Model {
-    window: window::Id,
+    window: WindowId,
 }
 
 fn model(app: &App) -> Model {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod frame;
 pub mod window;
 pub mod image;
 pub mod math;
+pub mod prelude;
 
 pub type ModelFn<Model> = fn(&App) -> Model;
 pub type UpdateFn<Model, Event> = fn(&App, Model, Event) -> Model;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,9 @@
+//! A collection of commonly used items that we recommend importing for ease of use.
+
+pub use app::{App, LoopMode};
+pub use event::SimpleWindowEvent::*;
+pub use event::Event;
+pub use frame::Frame;
+pub use math::{Point2, Point3, Vector2, Vector3, vec2, vec3};
+pub use math::prelude::*;
+pub use window::Id as WindowId;


### PR DESCRIPTION
This should simplify the process of kicking off a project with nannou.

At the moment I've just picked a few items which are already showing up
often in the examples. I don't have a particular rule in mind yet for
the kinds of items that should/shouldn't be added to the prelude. Maybe
we can come up with a set of rules for this, but for now I'm sure we
should be able to pick these pretty intuitively.

I guess this can be thought of as a more conservative `#include
ofMain.h` or Processing's list of auto-included items and keywords.

This closes #10.