### PR TITLE
Remove `Other` variant from `SimpleWindowEvent` in favour of `Option`.

### DIFF
--- a/examples/loop_mode.rs
+++ b/examples/loop_mode.rs
@@ -18,16 +18,19 @@ fn model(app: &App) -> Model {
 }
 
 fn update(app: &App, model: Model, event: Event) -> Model {
-    println!("{:?}", event);
     match event {
-        Event::WindowEvent(_id, event) => match event.simple {
-            KeyPressed(_) => match app.loop_mode() {
-                LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
-                LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
+        Event::WindowEvent { simple: Some(event), .. } => match event {
+            KeyPressed(_) => {
+                match app.loop_mode() {
+                    LoopMode::Rate { .. } => app.set_loop_mode(LoopMode::wait(3)),
+                    LoopMode::Wait { .. } => app.set_loop_mode(LoopMode::rate_fps(60.0)),
+                }
+                println!("Loop mode switched to: {:?}", app.loop_mode());
             },
             _ => (),
         },
-        Event::Update(_update) => {
+        Event::Update(update) => {
+            println!("{:?}", update);
         },
         _ => (),
     }

--- a/examples/multi_window.rs
+++ b/examples/multi_window.rs
@@ -22,8 +22,8 @@ fn model(app: &App) -> Model {
 fn update(_app: &App, model: Model, event: Event) -> Model {
     match event {
         // Handle window events like mouse, keyboard, resize, etc here.
-        Event::WindowEvent(id, event) => {
-            println!("Window {:?}: {:?}", id, event.simple);
+        Event::WindowEvent { id, simple: Some(event), .. } => {
+            println!("Window {:?}: {:?}", id, event);
         },
         // `Update` the model here.
         Event::Update(_update) => {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -18,8 +18,8 @@ fn model(app: &App) -> Model {
 fn update(_app: &App, model: Model, event: Event) -> Model {
     match event {
         // Handle window events like mouse, keyboard, resize, etc here.
-        Event::WindowEvent(_id, event) => {
-            println!("{:?}", event.simple);
+        Event::WindowEvent { simple: Some(event), .. } => {
+            println!("{:?}", event);
         },
         // `Update` the model here.
         Event::Update(_update) => {

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -17,7 +17,7 @@ fn model(app: &App) -> Model {
 
 fn event(_app: &App, model: Model, event: Event) -> Model {
     match event {
-        Event::WindowEvent(_id, event) => match event.simple {
+        Event::WindowEvent { simple: Some(event), .. } => match event {
 
             Moved(_pos) => {
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,10 @@ fn run_loop<M, E>(mut app: App, mut model: M, update_fn: UpdateFn<M, E>, draw_fn
             }
         }
 
-        let event = E::from_glutin_event(glutin_event, app);
-        model = update_fn(&app, model, event);
+        // If the glutin::Event could be interpreted as some event `E`, use it to update the model.
+        if let Some(event) = E::from_glutin_event(glutin_event, app) {
+            model = update_fn(&app, model, event);
+        }
 
         // If exit on escape was triggered, we're done.
         let exit = if exit_on_escape || app.displays.borrow().is_empty() {


### PR DESCRIPTION
I think this makes a bit more sense semantically, rather than just
delivering a meaningless `Other` variant for every raw event that cannot
be interpreted as a `SimpleWindowEvent`.

This also improves the `simple_window` example where we print out each
emitted `SimpleWindowEvent`, as we no longer have `Other` spammed
between all the events that actually mean something.

There is a slight trade-off here in that the pattern matching is not
*quite* as simple as it was originally, however I think what's actually
going on should hopefully still be pretty obvious?

cc @freesig @JoshuaBatty

This also adds some more docs to the event conversion functions and fixes a bug in the `from_glutin_event` function where nannou used to `panic!` when receiving a `Closed` event.

Edit: this also makes the `loop_mode` a little more user friendly and only prints out `Update` events in order to make the loop mode switching more obvious, rather than printing out every event that occurs which tends to spam stdout pretty hard.