### PR TITLE
Add optional exit function for consuming model on application exit

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@ pub use glium::glutin::{ElementState, KeyboardInput, MouseButton, MouseScrollDel
 
 /// Event types that are compatible with the nannou app loop.
 pub trait LoopEvent: From<Update> {
+    /// Produce a loop event from the given glutin event.
     fn from_glutin_event(glutin::Event, &App) -> Option<Self>;
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -258,6 +258,11 @@ impl Ui {
     ///
     /// This method *drives* the **Ui** forward and interprets input into higher-level events (like
     /// clicks and drags) for widgets.
+    ///
+    /// Note: By default, this will be called automatically by the nannou `App`, so most of the
+    /// time you should not need to call this (otherwise received inputs may double up). This
+    /// method is particularly useful in the case that automatic input handling has been disabled,
+    /// as this can be used to manually submit inputs.
     pub fn handle_input(&mut self, input: Input) {
         self.ui.handle_event(input)
     }


### PR DESCRIPTION
This gives the user the option of taking back ownership of their `Model` on application exit (this can be useful for joining threads, triggering destructors in a certain order, etc).