### PR TITLE
Change audio::stream::Output::send API to take FnOnce instead of FnMut

### DIFF
--- a/src/audio/stream/mod.rs
+++ b/src/audio/stream/mod.rs
@@ -18,4 +18,4 @@ pub mod duplex {}
 pub const DEFAULT_SAMPLE_RATE: u32 = 44_100;
 
 /// The type of function accepted for model updates.
-pub type UpdateFn<M> = FnMut(&mut M) + Send + 'static;
+pub type UpdateFn<M> = FnOnce(&mut M) + Send + 'static;


### PR DESCRIPTION
This allows for a much more expressive audio update API as the compiler
now knows that audio model updates will only ever be called once. This
allows users to move non-Copy and non-Clone types into update closures.

Rust currently does not allow calling a `Box<FnOnce>` as the `FnOnce`
trait's `call` method takes `self` by value. To get around this, we move
the `FnOnce` closure into a `FnMut` closure on the stack before `Box`ing
it and sending it to the audio thread. We solve the ownership conflicts
between the `FnOnce` and `FnMut` functions by first moving the `FnOnce`
into an `Option` and calling `take()` within the `FnMut` closure,
ensuring that the type system knows that the `FnOnce` closure still only
gets called once.