### PR TITLE
Modify audio backend to properly handle multiple voices

### DIFF
--- a/examples/simple_audio.rs
+++ b/examples/simple_audio.rs
@@ -44,7 +44,7 @@ fn model(app: &App) -> Model {
     Model { window, stream }
 }
 
-fn update(_app: &App, mut model: Model, event: Event) -> Model {
+fn update(_app: &App, model: Model, event: Event) -> Model {
     match event {
         Event::WindowEvent { simple: Some(event), .. } => match event {
 


### PR DESCRIPTION
Rather than having each new voice attempt to `run` the
`cpal::EventLoop`, we now run the `cpal::EventLoop` when the first voice
is created and use a `LoopContext` to handle multiple voices.

It also ensures that the `audio::stream::Output` handle can be `Clone`d
and sent to multiple threads.