### PR TITLE
Make nannou smarter about audio output stream format defaults

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -4,7 +4,6 @@ pub extern crate sample;
 pub use self::buffer::Buffer;
 pub use self::requester::Requester;
 
-//pub mod backend;
 pub mod buffer;
 pub mod requester;
 pub mod stream;


### PR DESCRIPTION
This changes the audio output stream building process to pick more
reasonable defaults when certain parameters were not specified.

If no number of channels were specified, nannou will now attempt to use
all available output channels on the device.

If the target sample format happens to have an associated
`cpal::SampleFormat` that can be used for setting up a stream, nannou
will now first attempt to use a stream format with this matching sample
format to avoid the need for sample format conversions. If there are no
matching stream formats for the given sample format, nannou will fall
back to doing the conversion.