### PR TITLE
 Add `geom` module. Includes basic 2D primitives (besides lines/text). 

### DIFF
--- a/src/geom/ellipse.rs
+++ b/src/geom/ellipse.rs
@@ -1,0 +1,143 @@
+use geom::{Rect, Tri};
+use math::{self, BaseNum, Point2};
+use math::num_traits::{Float, NumCast};
+use std;
+use std::ops::Neg;
+
+/// An iterator yielding the edges of an ellipse (or some section of an `ellipse`) as a series of
+/// points.
+#[derive(Clone)]
+#[allow(missing_copy_implementations)]
+pub struct Circumference<S> {
+    index: usize,
+    num_points: usize,
+    point: Point2<S>,
+    rad_step: S,
+    rad_offset: S,
+    half_w: S,
+    half_h: S,
+}
+
+/// An iterator yielding triangles that describe an oval or some section of an oval.
+#[derive(Clone)]
+pub struct Triangles<S> {
+    // The last circumference point yielded by the `CircumferenceOffset` iterator.
+    last: Point2<S>,
+    // The circumference points used to yield yielded by the `CircumferenceOffset` iterator.
+    points: Circumference<S>,
+}
+
+impl<S> Circumference<S>
+where
+    S: BaseNum + Neg<Output=S>,
+{
+    fn new_inner(rect: Rect<S>, num_points: usize, rad_step: S) -> Self {
+        let (x, y, w, h) = rect.x_y_w_h();
+        let two = math::two();
+        Circumference {
+            index: 0,
+            num_points: num_points,
+            point: [x, y].into(),
+            half_w: w / two,
+            half_h: h / two,
+            rad_step: rad_step,
+            rad_offset: S::zero(),
+        }
+    }
+
+    /// An iterator yielding the ellipse's edges as a circumference represented as a series of
+    /// points.
+    ///
+    /// `resolution` is clamped to a minimum of `1` as to avoid creating a `Circumference` that
+    /// produces `NaN` values.
+    pub fn new(rect: Rect<S>, mut resolution: usize) -> Self {
+        resolution = std::cmp::max(resolution, 1);
+        use std::f64::consts::PI;
+        let radians = S::from(2.0 * PI).unwrap();
+        Self::new_section(rect, resolution, radians)
+    }
+
+    /// Produces a new iterator that yields only a section of the ellipse's circumference, where
+    /// the section is described via its angle in radians.
+    ///
+    /// `resolution` is clamped to a minimum of `1` as to avoid creating a `Circumference` that
+    /// produces `NaN` values.
+    pub fn new_section(rect: Rect<S>, resolution: usize, radians: S) -> Self
+    where
+        S: BaseNum,
+    {
+        let res = S::from(resolution).unwrap();
+        Self::new_inner(rect, resolution + 1, radians / res)
+    }
+
+    /// Produces a new iterator that yields only a section of the ellipse's circumference, where
+    /// the section is described via its angle in radians.
+    pub fn section(mut self, radians: S) -> Self {
+        let resolution = self.num_points - 1;
+        let res = S::from(resolution).unwrap();
+        self.rad_step = radians / res;
+        self
+    }
+
+    /// Rotates the position at which the iterator starts yielding points by the given radians.
+    ///
+    /// This is particularly useful for yielding a different section of the circumference when
+    /// using `circumference_section`
+    pub fn offset_radians(mut self, radians: S) -> Self {
+        self.rad_offset = radians;
+        self
+    }
+
+    /// Produces an `Iterator` yielding `Triangle`s.
+    ///
+    /// Triangles are created by joining each edge yielded by the inner `Circumference` to the
+    /// middle of the ellipse.
+    pub fn triangles(mut self) -> Triangles<S>
+    where
+        S: Float,
+    {
+        let last = self.next().unwrap_or(self.point);
+        Triangles { last, points: self }
+    }
+}
+
+impl<S> Iterator for Circumference<S>
+where
+    S: BaseNum + Float,
+{
+    type Item = Point2<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Circumference {
+            ref mut index,
+            num_points,
+            point,
+            rad_step,
+            rad_offset,
+            half_w,
+            half_h,
+        } = *self;
+        if *index >= num_points {
+            return None;
+        }
+        let index_s: S = NumCast::from(*index).unwrap();
+        let x = point.x + half_w * (rad_offset + rad_step * index_s).cos();
+        let y = point.y + half_h * (rad_offset + rad_step * index_s).sin();
+        *index += 1;
+        Some([x, y].into())
+    }
+}
+
+impl<S> Iterator for Triangles<S>
+where
+    S: BaseNum + Float,
+{
+    type Item = Tri<Point2<S>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Triangles { ref mut points, ref mut last } = *self;
+        points.next().map(|next| {
+            let triangle = Tri([points.point, *last, next]);
+            *last = next;
+            triangle
+        })
+    }
+}

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -1,0 +1,10 @@
+pub mod ellipse;
+pub mod polygon;
+pub mod quad;
+pub mod range;
+pub mod rect;
+pub mod tri;
+
+pub use self::range::{Align, Edge, Range};
+pub use self::rect::{Corner, Padding, Rect};
+pub use self::tri::Tri;

--- a/src/geom/polygon.rs
+++ b/src/geom/polygon.rs
@@ -1,0 +1,62 @@
+use geom::tri::{self, Tri};
+
+/// An iterator that triangulates a polygon represented by a sequence of points describing its
+/// edges.
+#[derive(Clone)]
+pub struct Triangles<I>
+where
+    I: Iterator,
+{
+    first: I::Item,
+    prev: I::Item,
+    points: I,
+}
+
+/// Triangulate the polygon given as a list of `Point`s describing its sides.
+///
+/// Returns `None` if the given iterator yields less than two points.
+pub fn triangles<I>(points: I) -> Option<Triangles<I::IntoIter>>
+where
+    I: IntoIterator,
+    I::Item: tri::Vertex2d,
+{
+    let mut points = points.into_iter();
+    let first = match points.next() {
+        Some(p) => p,
+        None => return None,
+    };
+    let prev = match points.next() {
+        Some(p) => p,
+        None => return None,
+    };
+    Some(Triangles {
+        first: first,
+        prev: prev,
+        points: points,
+    })
+}
+
+impl<I> Iterator for Triangles<I>
+where
+    I: Iterator,
+    I::Item: tri::Vertex2d,
+{
+    type Item = Tri<I::Item>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.points.next().map(|point| {
+            let t = Tri([self.first, self.prev, point]);
+            self.prev = point;
+            t
+        })
+    }
+}
+
+/// Returns `true` if the given `Point` is over the polygon described by the given series of
+/// points.
+pub fn contains<I>(points: I, point: I::Item) -> Option<Tri<I::Item>>
+where
+    I: IntoIterator,
+    I::Item: tri::Vertex2d,
+{
+    triangles(points).and_then(|ts| tri::iter_contains(ts, point))
+}

--- a/src/geom/quad.rs
+++ b/src/geom/quad.rs
@@ -1,0 +1,59 @@
+use geom::Tri;
+use math::Point2;
+
+/// Triangulates the given quad, represented by four points that describe its edges in either
+/// clockwise or anti-clockwise order.
+///
+/// # Example
+///
+/// The following rectangle
+///
+/// ```ignore
+///
+///  a        b
+///   --------
+///   |      |
+///   |      |
+///   |      |
+///   --------
+///  d        c
+///
+/// ```
+///
+/// given as
+///
+/// ```ignore
+/// triangles([a, b, c, d])
+/// ```
+///
+/// returns
+///
+/// ```ignore
+/// (Tri([a, b, c]), Tri([a, c, d]))
+/// ```
+///
+/// Here's a basic code example:
+///
+/// ```
+/// extern crate nannou;
+///
+/// use nannou::geom::{self, Tri};
+///
+/// fn main() {
+///     let a = [0.0, 1.0].into();
+///     let b = [1.0, 1.0].into();
+///     let c = [1.0, 0.0].into();
+///     let d = [0.0, 0.0].into();
+///     let quad = [a, b, c, d];
+///     let triangles = geom::quad::triangles(&quad);
+///     assert_eq!(triangles, (Tri([a, b, c]), Tri([a, c, d])));
+/// }
+/// ```
+#[inline]
+pub fn triangles<S>(points: &[Point2<S>; 4]) -> (Tri<Point2<S>>, Tri<Point2<S>>)
+where
+    S: Copy,
+{
+    let (a, b, c, d) = (points[0], points[1], points[2], points[3]);
+    (Tri([a, b, c]), Tri([a, c, d]))
+}

--- a/src/geom/range.rs
+++ b/src/geom/range.rs
@@ -1,0 +1,666 @@
+//! A type for working with one-dimensional ranges.
+
+use math::{self, BaseNum, two};
+use math::num_traits::{Float, One, Zero};
+use std::ops::Neg;
+
+/// Some start and end position along a single axis.
+///
+/// As an example, a **Rect** is made up of two **Range**s; one along the *x* axis, and one along
+/// the *y* axis.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Range<S = f64> {
+    /// The start of some `Range` along an axis.
+    pub start: S,
+    /// The end of some `Range` along an axis.
+    pub end: S,
+}
+
+/// Represents either the **Start** or **End** **Edge** of a **Range**.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Edge {
+    /// The beginning of a **Range**.
+    Start,
+    /// The end of a **Range**.
+    End,
+}
+
+/// Describes alignment along a range.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Align { Start, Middle, End }
+
+impl<S> Range<S>
+where
+    S: BaseNum,
+{
+    /// Construct a new `Range` from a given range, i.e. `Range::new(start, end)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range { start: 0.0, end: 10.0 }, Range::new(0.0, 10.0));
+    /// ```
+    pub fn new(start: S, end: S) -> Self {
+        Range {
+            start: start,
+            end: end,
+        }
+    }
+
+    /// Construct a new `Range` from a given length and its centered position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0), Range::from_pos_and_len(5.0, 10.0));
+    /// assert_eq!(Range::new(-5.0, 1.0), Range::from_pos_and_len(-2.0, 6.0));
+    /// assert_eq!(Range::new(-100.0, 200.0), Range::from_pos_and_len(50.0, 300.0));
+    /// ```
+    pub fn from_pos_and_len(pos: S, len: S) -> Self {
+        let half_len = len / two();
+        let start = pos - half_len;
+        let end = pos + half_len;
+        Range::new(start, end)
+    }
+
+    /// The `start` value subtracted from the `end` value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(-5.0, 5.0).magnitude(), 10.0);
+    /// assert_eq!(Range::new(5.0, -5.0).magnitude(), -10.0);
+    /// assert_eq!(Range::new(15.0, 10.0).magnitude(), -5.0);
+    /// ```
+    pub fn magnitude(&self) -> S {
+        self.end - self.start
+    }
+
+    /// The absolute length of the Range aka the absolute magnitude.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(-5.0, 5.0).len(), 10.0);
+    /// assert_eq!(Range::new(5.0, -5.0).len(), 10.0);
+    /// assert_eq!(Range::new(15.0, 10.0).len(), 5.0);
+    /// ```
+    pub fn len(&self) -> S
+    where
+        S: Neg<Output=S>,
+    {
+        let mag = self.magnitude();
+        let zero = S::zero();
+        if mag < zero { -mag } else { mag }
+    }
+
+    /// Return the value directly between the start and end values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(-5.0, 5.0).middle(), 0.0);
+    /// assert_eq!(Range::new(5.0, -5.0).middle(), 0.0);
+    /// assert_eq!(Range::new(10.0, 15.0).middle(), 12.5);
+    /// assert_eq!(Range::new(20.0, 40.0).middle(), 30.0);
+    /// assert_eq!(Range::new(20.0, -40.0).middle(), -10.0);
+    /// ```
+    pub fn middle(&self) -> S {
+        (self.end + self.start) / two()
+    }
+
+    /// The current range with its start and end values swapped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(-5.0, 5.0).invert(), Range::new(5.0, -5.0));
+    /// assert_eq!(Range::new(-10.0, 10.0).invert(), Range::new(10.0, -10.0));
+    /// assert_eq!(Range::new(0.0, 7.25).invert(), Range::new(7.25, 0.0));
+    /// assert_eq!(Range::new(5.0, 1.0).invert(), Range::new(1.0, 5.0));
+    /// ```
+    pub fn invert(self) -> Self {
+        Range { start: self.end, end: self.start }
+    }
+
+    /// Map the given scalar from `Self` to some other given `Range`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(0.0, 5.0);
+    ///
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.map_value(2.5, &b), 5.0);
+    /// assert_eq!(a.map_value(0.0, &b), 0.0);
+    /// assert_eq!(a.map_value(5.0, &b), 10.0);
+    /// assert_eq!(a.map_value(-5.0, &b), -10.0);
+    /// assert_eq!(a.map_value(10.0, &b), 20.0);
+    ///
+    /// let c = Range::new(10.0, -10.0);
+    /// assert_eq!(a.map_value(2.5, &c), 0.0);
+    /// assert_eq!(a.map_value(0.0, &c), 10.0);
+    /// assert_eq!(a.map_value(5.0, &c), -10.0);
+    /// assert_eq!(a.map_value(-5.0, &c), 30.0);
+    /// assert_eq!(a.map_value(10.0, &c), -30.0);
+    /// ```
+    pub fn map_value(&self, value: S, other: &Self) -> S {
+        math::map_range(value, self.start, self.end, other.start, other.end)
+    }
+
+    /// Shift the `Range` start and end points by a given scalar.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 5.0).shift(5.0), Range::new(5.0, 10.0));
+    /// assert_eq!(Range::new(0.0, 5.0).shift(-5.0), Range::new(-5.0, 0.0));
+    /// assert_eq!(Range::new(5.0, -5.0).shift(-5.0), Range::new(0.0, -10.0));
+    /// ```
+    pub fn shift(self, amount: S) -> Self {
+        Range { start: self.start + amount, end: self.end + amount }
+    }
+
+    /// The direction of the Range represented as a normalised scalar.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 5.0).direction(), 1.0);
+    /// assert_eq!(Range::new(0.0, 0.0).direction(), 0.0);
+    /// assert_eq!(Range::new(0.0, -5.0).direction(), -1.0);
+    /// ```
+    pub fn direction(&self) -> S
+    where
+        S: Neg<Output=S> + One + Zero,
+    {
+        if      self.start < self.end { S::one() }
+        else if self.start > self.end { -S::one() }
+        else                          { S::zero() }
+    }
+
+    /// Converts the Range to an undirected Range. By ensuring that `start` <= `end`.
+    ///
+    /// If `start` > `end`, then the start and end points will be swapped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 5.0).undirected(), Range::new(0.0, 5.0));
+    /// assert_eq!(Range::new(5.0, 1.0).undirected(), Range::new(1.0, 5.0));
+    /// assert_eq!(Range::new(10.0, -10.0).undirected(), Range::new(-10.0, 10.0));
+    /// ```
+    pub fn undirected(self) -> Self {
+        if self.start > self.end { self.invert() } else { self }
+    }
+
+    /// The Range that encompasses both self and the given Range.
+    ///
+    /// The returned Range's `start` will always be <= its `end`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(0.0, 3.0);
+    /// let b = Range::new(7.0, 10.0);
+    /// assert_eq!(a.max(b), Range::new(0.0, 10.0));
+    ///
+    /// let c = Range::new(-20.0, -30.0);
+    /// let d = Range::new(5.0, -7.5);
+    /// assert_eq!(c.max(d), Range::new(-30.0, 5.0));
+    /// ```
+    pub fn max(self, other: Self) -> Self
+    where
+        S: Float,
+    {
+        let start = self.start.min(self.end).min(other.start).min(other.end);
+        let end = self.start.max(self.end).max(other.start).max(other.end);
+        Range::new(start, end)
+    }
+
+    /// The Range that represents the range of the overlap between two Ranges if there is some.
+    ///
+    /// Note that If one end of `self` aligns exactly with the opposite end of `other`, `Some`
+    /// `Range` will be returned with a magnitude of `0.0`. This is useful for algorithms that
+    /// involve calculating the visibility of widgets, as it allows for including widgets whose
+    /// bounding box may be a one dimensional straight line.
+    ///
+    /// The returned `Range`'s `start` will always be <= its `end`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(0.0, 6.0);
+    /// let b = Range::new(4.0, 10.0);
+    /// assert_eq!(a.overlap(b), Some(Range::new(4.0, 6.0)));
+    ///
+    /// let c = Range::new(10.0, -30.0);
+    /// let d = Range::new(-5.0, 20.0);
+    /// assert_eq!(c.overlap(d), Some(Range::new(-5.0, 10.0)));
+    /// 
+    /// let e = Range::new(0.0, 2.5);
+    /// let f = Range::new(50.0, 100.0);
+    /// assert_eq!(e.overlap(f), None);
+    /// ```
+    pub fn overlap(mut self, mut other: Self) -> Option<Self> {
+        self = self.undirected();
+        other = other.undirected();
+        let start = math::partial_max(self.start, other.start);
+        let end = math::partial_min(self.end, other.end);
+        let magnitude = end - start;
+        if magnitude >= S::zero() {
+            Some(Range::new(start, end))
+        } else {
+            None
+        }
+    }
+
+    /// The Range that encompasses both self and the given Range.
+    ///
+    /// The same as [**Range::max**](./struct.Range#method.max) but retains `self`'s original
+    /// direction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(0.0, 3.0);
+    /// let b = Range::new(7.0, 10.0);
+    /// assert_eq!(a.max_directed(b), Range::new(0.0, 10.0));
+    ///
+    /// let c = Range::new(-20.0, -30.0);
+    /// let d = Range::new(5.0, -7.5);
+    /// assert_eq!(c.max_directed(d), Range::new(5.0, -30.0));
+    /// ```
+    pub fn max_directed(self, other: Self) -> Self
+    where
+        S: Float,
+    {
+        if self.start <= self.end { self.max(other) }
+        else                      { self.max(other).invert() }
+    }
+
+    /// Is the given scalar within our range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let range = Range::new(0.0, 10.0);
+    /// assert!(range.contains(5.0));
+    /// assert!(!range.contains(12.0));
+    /// assert!(!range.contains(-1.0));
+    /// assert!(range.contains(0.0));
+    /// assert!(range.contains(10.0));
+    /// ```
+    pub fn contains(&self, pos: S) -> bool {
+        let Range { start, end } = self.undirected();
+        start <= pos && pos <= end
+    }
+
+    /// Round the values at both ends of the Range and return the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.25, 9.5).round(), Range::new(0.0, 10.0));
+    /// assert_eq!(Range::new(4.95, -5.3).round(), Range::new(5.0, -5.0));
+    /// ```
+    pub fn round(self) -> Self
+    where
+        S: Float,
+    {
+        Self::new(self.start.round(), self.end.round())
+    }
+
+    /// Floor the values at both ends of the Range and return the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.25, 9.5).floor(), Range::new(0.0, 9.0));
+    /// assert_eq!(Range::new(4.95, -5.3).floor(), Range::new(4.0, -6.0));
+    /// ```
+    pub fn floor(self) -> Self
+    where
+        S: Float,
+    {
+        Self::new(self.start.floor(), self.end.floor())
+    }
+
+    /// The Range with some padding given to the `start` value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0).pad_start(2.0), Range::new(2.0, 10.0));
+    /// assert_eq!(Range::new(10.0, 0.0).pad_start(2.0), Range::new(8.0, 0.0));
+    /// ```
+    pub fn pad_start(mut self, pad: S) -> Self
+    where
+        S: Neg<Output=S>,
+    {
+        self.start += if self.start <= self.end { pad } else { -pad };
+        self
+    }
+
+    /// The Range with some padding given to the `end` value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0).pad_end(2.0), Range::new(0.0, 8.0));
+    /// assert_eq!(Range::new(10.0, 0.0).pad_end(2.0), Range::new(10.0, 2.0));
+    /// ```
+    pub fn pad_end(mut self, pad: S) -> Self
+    where
+        S: Neg<Output=S>,
+    {
+        self.end += if self.start <= self.end { -pad } else { pad };
+        self
+    }
+
+    /// The Range with some given padding to be applied to each end.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0).pad(2.0), Range::new(2.0, 8.0));
+    /// assert_eq!(Range::new(10.0, 0.0).pad(2.0), Range::new(8.0, 2.0));
+    /// ```
+    pub fn pad(self, pad: S) -> Self
+    where
+        S: Neg<Output=S>,
+    {
+        self.pad_start(pad).pad_end(pad)
+    }
+
+    /// The Range with some padding given for each end.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0).pad_ends(1.0, 2.0), Range::new(1.0, 8.0));
+    /// assert_eq!(Range::new(10.0, 0.0).pad_ends(4.0, 3.0), Range::new(6.0, 3.0));
+    /// ```
+    pub fn pad_ends(self, start: S, end: S) -> Self
+    where
+        S: Neg<Output=S>,
+    {
+        self.pad_start(start).pad_end(end)
+    }
+
+    /// Clamp the given value to the range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert_eq!(Range::new(0.0, 5.0).clamp_value(7.0), 5.0);
+    /// assert_eq!(Range::new(5.0, -2.5).clamp_value(-3.0), -2.5);
+    /// assert_eq!(Range::new(5.0, 10.0).clamp_value(0.0), 5.0);
+    /// ```
+    pub fn clamp_value(&self, value: S) -> S {
+        math::clamp(value, self.start, self.end)
+    }
+
+    /// Stretch the end that is closest to the given value only if it lies outside the Range.
+    ///
+    /// The resulting Range will retain the direction of the original range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(2.5, 5.0);
+    /// assert_eq!(a.stretch_to_value(10.0), Range::new(2.5, 10.0));
+    /// assert_eq!(a.stretch_to_value(0.0), Range::new(0.0, 5.0));
+    ///
+    /// let b = Range::new(0.0, -5.0);
+    /// assert_eq!(b.stretch_to_value(10.0), Range::new(10.0, -5.0));
+    /// assert_eq!(b.stretch_to_value(-10.0), Range::new(0.0, -10.0));
+    /// ```
+    pub fn stretch_to_value(self, value: S) -> Self {
+        let Range { start, end } = self;
+        if start <= end {
+            if value < start {
+                Range { start: value, end: end }
+            } else if value > end {
+                Range { start: start, end: value }
+            } else {
+                self
+            }
+        } else {
+            if value < end {
+                Range { start: start, end: value }
+            } else if value > start {
+                Range { start: value, end: end }
+            } else {
+                self
+            }
+        }
+    }
+
+    /// Does `self` have the same direction as `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// assert!(Range::new(0.0, 1.0).has_same_direction(Range::new(100.0, 200.0)));
+    /// assert!(Range::new(0.0, -5.0).has_same_direction(Range::new(-2.5, -6.0)));
+    /// assert!(!Range::new(0.0, 5.0).has_same_direction(Range::new(2.5, -2.5)));
+    /// ```
+    pub fn has_same_direction(self, other: Self) -> bool {
+        let self_direction = self.start <= self.end;
+        let other_direction = other.start <= other.end;
+        self_direction == other_direction
+    }
+
+    /// Align the `start` of `self` to the `start` of the `other` **Range**.
+    ///
+    /// If the direction of `other` is different to `self`, `self`'s `end` will be aligned to the
+    /// `start` of `other` instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(2.5, 7.5);
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.align_start_of(b), Range::new(0.0, 5.0));
+    /// assert_eq!(b.align_start_of(a), Range::new(2.5, 12.5));
+    ///
+    /// let c = Range::new(2.5, -2.5);
+    /// let d = Range::new(-5.0, 5.0);
+    /// assert_eq!(c.align_start_of(d), Range::new(0.0, -5.0));
+    /// assert_eq!(d.align_start_of(c), Range::new(-7.5, 2.5));
+    /// ```
+    pub fn align_start_of(self, other: Self) -> Self {
+        let diff = if self.has_same_direction(other) {
+            other.start - self.start
+        } else {
+            other.start - self.end
+        };
+        self.shift(diff)
+    }
+
+    /// Align the `end` of `self` to the `end` of the `other` **Range**.
+    ///
+    /// If the direction of `other` is different to `self`, `self`'s `start` will be aligned to the
+    /// `end` of `other` instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(2.5, 7.5);
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.align_end_of(b), Range::new(5.0, 10.0));
+    /// assert_eq!(b.align_end_of(a), Range::new(-2.5, 7.5));
+    ///
+    /// let c = Range::new(2.5, -2.5);
+    /// let d = Range::new(-5.0, 5.0);
+    /// assert_eq!(c.align_end_of(d), Range::new(5.0, 0.0));
+    /// assert_eq!(d.align_end_of(c), Range::new(-2.5, 7.5));
+    /// ```
+    pub fn align_end_of(self, other: Self) -> Self {
+        let diff = if self.has_same_direction(other) {
+            other.end - self.end
+        } else {
+            other.end - self.start
+        };
+        self.shift(diff)
+    }
+
+    /// Align the middle of `self` to the middle of the `other` **Range**.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(0.0, 5.0);
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.align_middle_of(b), Range::new(2.5, 7.5));
+    /// assert_eq!(b.align_middle_of(a), Range::new(-2.5, 7.5));
+    ///
+    /// let c = Range::new(2.5, -2.5);
+    /// let d = Range::new(-10.0, 0.0);
+    /// assert_eq!(c.align_middle_of(d), Range::new(-2.5, -7.5));
+    /// assert_eq!(d.align_middle_of(c), Range::new(-5.0, 5.0));
+    /// ```
+    pub fn align_middle_of(self, other: Self) -> Self {
+        let diff = other.middle() - self.middle();
+        self.shift(diff)
+    }
+
+    /// Aligns the `start` of `self` with the `end` of `other`.
+    ///
+    /// If the directions are opposite, aligns the `end` of self with the `end` of `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(2.5, 7.5);
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.align_after(b), Range::new(10.0, 15.0));
+    /// assert_eq!(b.align_after(a), Range::new(7.5, 17.5));
+    ///
+    /// let c = Range::new(2.5, -2.5);
+    /// let d = Range::new(-5.0, 5.0);
+    /// assert_eq!(c.align_after(d), Range::new(10.0, 5.0));
+    /// assert_eq!(d.align_after(c), Range::new(-12.5, -2.5));
+    /// ```
+    pub fn align_after(self, other: Self) -> Self {
+        let diff = if self.has_same_direction(other) {
+            other.end - self.start
+        } else {
+            other.end - self.end
+        };
+        self.shift(diff)
+    }
+
+    /// Aligns the `end` of `self` with the `start` of `other`.
+    ///
+    /// If the directions are opposite, aligns the `start` of self with the `start` of `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let a = Range::new(2.5, 7.5);
+    /// let b = Range::new(0.0, 10.0);
+    /// assert_eq!(a.align_before(b), Range::new(-5.0, 0.0));
+    /// assert_eq!(b.align_before(a), Range::new(-7.5, 2.5));
+    ///
+    /// let c = Range::new(2.5, -2.5);
+    /// let d = Range::new(-5.0, 5.0);
+    /// assert_eq!(c.align_before(d), Range::new(-5.0, -10.0));
+    /// assert_eq!(d.align_before(c), Range::new(2.5, 12.5));
+    /// ```
+    pub fn align_before(self, other: Self) -> Self {
+        let diff = if self.has_same_direction(other) {
+            other.start - self.end
+        } else {
+            other.start - self.start
+        };
+        self.shift(diff)
+    }
+
+    /// Align `self` to `other` along the *x* axis in accordance with the given `Align` variant.
+    pub fn align_to(self, align: Align, other: Self) -> Self {
+        match align {
+            Align::Start => self.align_start_of(other),
+            Align::Middle => self.align_middle_of(other),
+            Align::End => self.align_end_of(other),
+        }
+    }
+
+    /// The closest **Edge** of `self` to the given `scalar`.
+    ///
+    /// Returns **Start** if the distance between both **Edge**s is equal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::{Edge, Range};
+    ///
+    /// assert_eq!(Range::new(0.0, 10.0).closest_edge(4.0), Edge::Start);
+    /// assert_eq!(Range::new(0.0, 10.0).closest_edge(7.0), Edge::End);
+    /// assert_eq!(Range::new(0.0, 10.0).closest_edge(5.0), Edge::Start);
+    /// ```
+    pub fn closest_edge(&self, scalar: S) -> Edge {
+        let Range { start, end } = *self;
+        let start_diff = if scalar < start { start - scalar } else { scalar - start };
+        let end_diff = if scalar < end { end - scalar } else { scalar - end };
+        if start_diff <= end_diff { Edge::Start } else { Edge::End }
+    }
+
+}

--- a/src/geom/rect.rs
+++ b/src/geom/rect.rs
@@ -1,0 +1,487 @@
+use geom::{self, Align, Edge, Range, Tri};
+use math::{self, BaseNum, Point2, Vector2};
+use math::num_traits::Float;
+use std::ops::Neg;
+
+/// Defines a Rectangle's bounds across the x and y axes.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Rect<S = f64> {
+    /// The start and end positions of the Rectangle on the x axis.
+    pub x: Range<S>,
+    /// The start and end positions of the Rectangle on the y axis.
+    pub y: Range<S>,
+}
+
+/// The distance between the inner edge of a border and the outer edge of the inner content.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Padding<S> {
+    /// Padding on the start and end of the *x* axis.
+    pub x: Range<S>,
+    /// Padding on the start and end of the *y* axis.
+    pub y: Range<S>,
+}
+
+/// Either of the four corners of a **Rect**.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Corner {
+    /// The top left corner of a **Rect**.
+    TopLeft,
+    /// The top right corner of a **Rect**.
+    TopRight,
+    /// The bottom left corner of a **Rect**.
+    BottomLeft,
+    /// The bottom right corner of a **Rect**.
+    BottomRight,
+}
+
+impl<S> Padding<S>
+where
+    S: BaseNum,
+{
+    /// No padding.
+    pub fn none() -> Self {
+        Padding {
+            x: Range::new(S::zero(), S::zero()),
+            y: Range::new(S::zero(), S::zero()),
+        }
+    }
+}
+
+impl<S> Rect<S>
+where
+    S: BaseNum,
+{
+    /// Construct a Rect from a given `Point` and `Dimensions`.
+    pub fn from_xy_wh(p: Point2<S>, wh: Vector2<S>) -> Self {
+        Rect {
+            x: Range::from_pos_and_len(p.x, wh.x),
+            y: Range::from_pos_and_len(p.y, wh.y),
+        }
+    }
+
+    /// Construct a Rect from the coordinates of two points.
+    pub fn from_corners(a: Point2<S>, b: Point2<S>) -> Self {
+        let (left, right) = if a.x < b.x { (a.x, b.x) } else { (b.x, a.x) };
+        let (bottom, top) = if a.y < b.y { (a.y, b.y) } else { (b.y, a.y) };
+        Rect {
+            x: Range {
+                start: left,
+                end: right,
+            },
+            y: Range {
+                start: bottom,
+                end: top,
+            },
+        }
+    }
+
+    /// The Rect representing the area in which two Rects overlap.
+    pub fn overlap(self, other: Self) -> Option<Self> {
+        self.x.overlap(other.x).and_then(|x| {
+            self.y.overlap(other.y).map(|y| Rect { x: x, y: y })
+        })
+    }
+
+    /// The Rect that encompass the two given sets of Rect.
+    pub fn max(self, other: Self) -> Self
+    where
+        S: Float,
+    {
+        Rect {
+            x: self.x.max(other.x),
+            y: self.y.max(other.y),
+        }
+    }
+
+    /// The position in the middle of the x bounds.
+    pub fn x(&self) -> S {
+        self.x.middle()
+    }
+
+    /// The position in the middle of the y bounds.
+    pub fn y(&self) -> S {
+        self.y.middle()
+    }
+
+    /// The xy position in the middle of the bounds.
+    pub fn xy(&self) -> Point2<S> {
+        [self.x(), self.y()].into()
+    }
+
+    /// The centered x and y coordinates as a tuple.
+    pub fn x_y(&self) -> (S, S) {
+        (self.x(), self.y())
+    }
+
+    /// The Rect's lowest y value.
+    pub fn bottom(&self) -> S {
+        self.y.undirected().start
+    }
+
+    /// The Rect's highest y value.
+    pub fn top(&self) -> S {
+        self.y.undirected().end
+    }
+
+    /// The Rect's lowest x value.
+    pub fn left(&self) -> S {
+        self.x.undirected().start
+    }
+
+    /// The Rect's highest x value.
+    pub fn right(&self) -> S {
+        self.x.undirected().end
+    }
+
+    /// The top left corner **Point**.
+    pub fn top_left(&self) -> Point2<S> {
+        [self.left(), self.top()].into()
+    }
+
+    /// The bottom left corner **Point**.
+    pub fn bottom_left(&self) -> Point2<S> {
+        [self.left(), self.bottom()].into()
+    }
+
+    /// The top right corner **Point**.
+    pub fn top_right(&self) -> Point2<S> {
+        [self.right(), self.top()].into()
+    }
+
+    /// The bottom right corner **Point**.
+    pub fn bottom_right(&self) -> Point2<S> {
+        [self.right(), self.bottom()].into()
+    }
+
+    /// The edges of the **Rect** in a tuple (top, bottom, left, right).
+    pub fn l_r_b_t(&self) -> (S, S, S, S) {
+        (self.left(), self.right(), self.bottom(), self.top())
+    }
+
+    /// Shift the Rect along the x axis.
+    pub fn shift_x(self, x: S) -> Self {
+        Rect {
+            x: self.x.shift(x),
+            ..self
+        }
+    }
+
+    /// Shift the Rect along the y axis.
+    pub fn shift_y(self, y: S) -> Self {
+        Rect {
+            y: self.y.shift(y),
+            ..self
+        }
+    }
+
+    /// Shift the Rect by the given Point.
+    pub fn shift(self, p: Point2<S>) -> Self {
+        self.shift_x(p.x).shift_y(p.y)
+    }
+
+    /// Does the given point touch the Rectangle.
+    pub fn contains(&self, p: Point2<S>) -> bool {
+        self.x.contains(p.x) && self.y.contains(p.y)
+    }
+
+    /// Stretches the closest edge(s) to the given point if the point lies outside of the Rect area.
+    pub fn stretch_to_point(self, point: Point2<S>) -> Self {
+        let Rect { x, y } = self;
+        Rect {
+            x: x.stretch_to_value(point[0]),
+            y: y.stretch_to_value(point[1]),
+        }
+    }
+
+    /// Align `self`'s right edge with the left edge of the `other` **Rect**.
+    pub fn left_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x.align_before(other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align `self`'s left edge with the right dge of the `other` **Rect**.
+    pub fn right_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x.align_after(other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align `self`'s top edge with the bottom edge of the `other` **Rect**.
+    pub fn below(self, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_before(other.x),
+        }
+    }
+
+    /// Align `self`'s bottom edge with the top edge of the `other` **Rect**.
+    pub fn above(self, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_after(other.x),
+        }
+    }
+
+    /// Align `self` to `other` along the *x* axis in accordance with the given `Align` variant.
+    pub fn align_x_of(self, align: Align, other: Self) -> Self {
+        Rect {
+            x: self.x.align_to(align, other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align `self` to `other` along the *y* axis in accordance with the given `Align` variant.
+    pub fn align_y_of(self, align: Align, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_to(align, other.y),
+        }
+    }
+
+    /// Align `self`'s left edge with the left edge of the `other` **Rect**.
+    pub fn align_left_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x.align_start_of(other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align the middle of `self` with the middle of the `other` **Rect** along the *x* axis.
+    pub fn align_middle_x_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x.align_middle_of(other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align `self`'s right edge with the right edge of the `other` **Rect**.
+    pub fn align_right_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x.align_end_of(other.x),
+            y: self.y,
+        }
+    }
+
+    /// Align `self`'s bottom edge with the bottom edge of the `other` **Rect**.
+    pub fn align_bottom_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_start_of(other.y),
+        }
+    }
+
+    /// Align the middle of `self` with the middle of the `other` **Rect** along the *y* axis.
+    pub fn align_middle_y_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_middle_of(other.y),
+        }
+    }
+
+    /// Align `self`'s top edge with the top edge of the `other` **Rect**.
+    pub fn align_top_of(self, other: Self) -> Self {
+        Rect {
+            x: self.x,
+            y: self.y.align_end_of(other.y),
+        }
+    }
+
+    /// Place `self` along the top left edges of the `other` **Rect**.
+    pub fn top_left_of(self, other: Self) -> Self {
+        self.align_left_of(other).align_top_of(other)
+    }
+
+    /// Place `self` along the top right edges of the `other` **Rect**.
+    pub fn top_right_of(self, other: Self) -> Self {
+        self.align_right_of(other).align_top_of(other)
+    }
+
+    /// Place `self` along the bottom left edges of the `other` **Rect**.
+    pub fn bottom_left_of(self, other: Self) -> Self {
+        self.align_left_of(other).align_bottom_of(other)
+    }
+
+    /// Place `self` along the bottom right edges of the `other` **Rect**.
+    pub fn bottom_right_of(self, other: Self) -> Self {
+        self.align_right_of(other).align_bottom_of(other)
+    }
+
+    /// Place `self` in the middle of the top edge of the `other` **Rect**.
+    pub fn mid_top_of(self, other: Self) -> Self {
+        self.align_middle_x_of(other).align_top_of(other)
+    }
+
+    /// Place `self` in the middle of the bottom edge of the `other` **Rect**.
+    pub fn mid_bottom_of(self, other: Self) -> Self {
+        self.align_middle_x_of(other).align_bottom_of(other)
+    }
+
+    /// Place `self` in the middle of the left edge of the `other` **Rect**.
+    pub fn mid_left_of(self, other: Self) -> Self {
+        self.align_left_of(other).align_middle_y_of(other)
+    }
+
+    /// Place `self` in the middle of the right edge of the `other` **Rect**.
+    pub fn mid_right_of(self, other: Self) -> Self {
+        self.align_right_of(other).align_middle_y_of(other)
+    }
+
+    /// Place `self` directly in the middle of the `other` **Rect**.
+    pub fn middle_of(self, other: Self) -> Self {
+        self.align_middle_x_of(other).align_middle_y_of(other)
+    }
+
+    /// Return the **Corner** of `self` that is closest to the given **Point**.
+    pub fn closest_corner(&self, p: Point2<S>) -> Corner {
+        let x_edge = self.x.closest_edge(p.x);
+        let y_edge = self.y.closest_edge(p.y);
+        match (x_edge, y_edge) {
+            (Edge::Start, Edge::Start) => Corner::BottomLeft,
+            (Edge::Start, Edge::End) => Corner::TopLeft,
+            (Edge::End, Edge::Start) => Corner::BottomRight,
+            (Edge::End, Edge::End) => Corner::TopRight,
+        }
+    }
+
+    /// Thee four corners of the `Rect`.
+    pub fn corners(&self) -> [Point2<S>; 4] {
+        let (l, r, b, t) = self.l_r_b_t();
+        let lb = [l, b].into();
+        let lt = [l, t].into();
+        let rt = [r, t].into();
+        let rb = [r, b].into();
+        [lb, lt, rt, rb]
+    }
+
+    /// Return two `Tri`s that represent the `Rect`.
+    pub fn triangles(&self) -> (Tri<Point2<S>>, Tri<Point2<S>>) {
+        let corners = self.corners();
+        geom::quad::triangles(&corners)
+    }
+}
+
+impl<S> Rect<S>
+where
+    S: BaseNum + Neg<Output = S>,
+{
+    /// The width of the Rect.
+    pub fn w(&self) -> S {
+        self.x.len()
+    }
+
+    /// The height of the Rect.
+    pub fn h(&self) -> S {
+        self.y.len()
+    }
+
+    /// The total dimensions of the Rect.
+    pub fn wh(&self) -> Vector2<S> {
+        [self.w(), self.h()].into()
+    }
+
+    /// The width and height of the Rect as a tuple.
+    pub fn w_h(&self) -> (S, S) {
+        (self.w(), self.h())
+    }
+
+    /// Convert the Rect to a `Point` and `Dimensions`.
+    pub fn xy_wh(&self) -> (Point2<S>, Vector2<S>) {
+        (self.xy(), self.wh())
+    }
+
+    /// The Rect's centered coordinates and dimensions in a tuple.
+    pub fn x_y_w_h(&self) -> (S, S, S, S) {
+        let (xy, wh) = self.xy_wh();
+        (xy[0], xy[1], wh[0], wh[1])
+    }
+
+    /// The length of the longest side of the rectangle.
+    pub fn len(&self) -> S {
+        math::partial_max(self.w(), self.h())
+    }
+
+    /// The left and top edges of the **Rect** along with the width and height.
+    pub fn l_t_w_h(&self) -> (S, S, S, S) {
+        let (w, h) = self.w_h();
+        (self.left(), self.top(), w, h)
+    }
+
+    /// The left and bottom edges of the **Rect** along with the width and height.
+    pub fn l_b_w_h(&self) -> (S, S, S, S) {
+        let (w, h) = self.w_h();
+        (self.left(), self.bottom(), w, h)
+    }
+
+    /// The Rect with some padding applied to the left edge.
+    pub fn pad_left(self, pad: S) -> Self {
+        Rect {
+            x: self.x.pad_start(pad),
+            ..self
+        }
+    }
+
+    /// The Rect with some padding applied to the right edge.
+    pub fn pad_right(self, pad: S) -> Self {
+        Rect {
+            x: self.x.pad_end(pad),
+            ..self
+        }
+    }
+
+    /// The rect with some padding applied to the bottom edge.
+    pub fn pad_bottom(self, pad: S) -> Self {
+        Rect {
+            y: self.y.pad_start(pad),
+            ..self
+        }
+    }
+
+    /// The Rect with some padding applied to the top edge.
+    pub fn pad_top(self, pad: S) -> Self {
+        Rect {
+            y: self.y.pad_end(pad),
+            ..self
+        }
+    }
+
+    /// The Rect with some padding amount applied to each edge.
+    pub fn pad(self, pad: S) -> Self {
+        let Rect { x, y } = self;
+        Rect {
+            x: x.pad(pad),
+            y: y.pad(pad),
+        }
+    }
+
+    /// The Rect with some padding applied.
+    pub fn padding(self, padding: Padding<S>) -> Self {
+        Rect {
+            x: self.x.pad_ends(padding.x.start, padding.x.end),
+            y: self.y.pad_ends(padding.y.start, padding.y.end),
+        }
+    }
+
+    /// Returns a `Rect` with a position relative to the given position on the *x* axis.
+    pub fn relative_to_x(self, x: S) -> Self {
+        Rect {
+            x: self.x.shift(-x),
+            ..self
+        }
+    }
+
+    /// Returns a `Rect` with a position relative to the given position on the *y* axis.
+    pub fn relative_to_y(self, y: S) -> Self {
+        Rect {
+            y: self.y.shift(-y),
+            ..self
+        }
+    }
+
+    /// Returns a `Rect` with a position relative to the given position.
+    pub fn relative_to(self, p: Point2<S>) -> Self {
+        self.relative_to_x(p.x).relative_to_y(p.y)
+    }
+}

--- a/src/geom/tri.rs
+++ b/src/geom/tri.rs
@@ -1,0 +1,179 @@
+use color::Rgba;
+use math::{BaseNum, Point2, Point3, Zero};
+use std::ops::Deref;
+
+/// A triangle as three vertices.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Tri<V = Point3<f64>>(pub [V; 3]);
+
+/// A vertex that is colored with the given linear `RGBA` color.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct RgbaVertex<V = Point3<f64>>(pub V, pub Rgba);
+
+/// Types used as vertices that can be used to describe a triangle.
+pub trait Vertex: Clone + Copy + PartialEq {
+    /// The values used to describe the vertex position.
+    type Scalar: BaseNum;
+}
+
+/// Two dimensional vertices.
+pub trait Vertex2d: Vertex {
+    /// The x, y location of the vertex.
+    fn point2(self) -> Point2<Self::Scalar>;
+}
+
+impl<S> Vertex for Point2<S>
+where
+    S: BaseNum,
+{
+    type Scalar = S;
+}
+
+impl<S> Vertex for Point3<S>
+where
+    S: BaseNum,
+{
+    type Scalar = S;
+}
+
+impl<V> Vertex for RgbaVertex<V>
+where
+    V: Vertex,
+{
+    type Scalar = V::Scalar;
+}
+
+impl<S> Vertex2d for Point2<S>
+where
+    S: BaseNum + Zero,
+{
+    fn point2(self) -> Point2<S> {
+        self
+    }
+}
+
+impl<V> Vertex2d for RgbaVertex<V>
+where
+    V: Vertex2d,
+{
+    fn point2(self) -> Point2<V::Scalar> {
+        self.0.point2()
+    }
+}
+
+impl<V> Tri<V> {
+    /// Returns `true` if the given 2D vertex is contained within the 2D `Tri`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate nannou;
+    /// # use nannou::prelude::*;
+    /// # use nannou::geom::Tri;
+    /// # fn main() {
+    /// let a = Point2 { x: -0.5, y: 0.0 };
+    /// let b = Point2 { x: 0.0, y: 1.0 };
+    /// let c = Point2 { x: 0.5, y: -0.75 };
+    /// let tri = Tri([a, b, c]);
+    /// assert!(tri.contains(&Point2 { x: 0.0, y: 0.0 }));
+    /// assert!(!tri.contains(&Point2 { x: 3.0, y: 3.0 }));
+    /// # }
+    /// ```
+    pub fn contains(&self, v: &V) -> bool
+    where
+        V: Vertex2d,
+    {
+        let (a, b, c) = (*self).into();
+        let (a, b, c) = (a.point2(), b.point2(), c.point2());
+        let v = (*v).point2();
+
+        fn sign<S>(a: Point2<S>, b: Point2<S>, c: Point2<S>) -> S
+        where
+            S: BaseNum,
+        {
+            (a[0] - c[0]) * (b[1] - c[1]) - (b[0] - c[0]) * (a[1] - c[1])
+        }
+
+        let b1 = sign(v, a, b) < V::Scalar::zero();
+        let b2 = sign(v, b, c) < V::Scalar::zero();
+        let b3 = sign(v, c, a) < V::Scalar::zero();
+
+        (b1 == b2) && (b2 == b3)
+    }
+}
+
+/// Returns the first `Tri` that contains the given vertex.
+///
+/// Returns `None` if no `Tri`'s contain the given vertex.
+pub fn iter_contains<I, V>(tris: I, v: V) -> Option<I::Item>
+where
+    I: IntoIterator,
+    I::Item: AsRef<Tri<V>>,
+    V: Vertex2d,
+{
+    tris.into_iter().find(|tri| tri.as_ref().contains(&v))
+}
+
+impl<V> Deref for Tri<V>
+where
+    V: Vertex,
+{
+    type Target = [V; 3];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> From<[V; 3]> for Tri<V>
+where
+    V: Vertex,
+{
+    fn from(points: [V; 3]) -> Self {
+        Tri(points)
+    }
+}
+
+impl<V> From<(V, V, V)> for Tri<V>
+where
+    V: Vertex,
+{
+    fn from((a, b, c): (V, V, V)) -> Self {
+        Tri([a, b, c])
+    }
+}
+
+impl<V> Into<[V; 3]> for Tri<V>
+where
+    V: Vertex,
+{
+    fn into(self) -> [V; 3] {
+        self.0
+    }
+}
+
+impl<V> Into<(V, V, V)> for Tri<V>
+where
+    V: Vertex,
+{
+    fn into(self) -> (V, V, V) {
+        (self[0], self[1], self[2])
+    }
+}
+
+impl<V> AsRef<Tri<V>> for Tri<V>
+where
+    V: Vertex,
+{
+    fn as_ref(&self) -> &Tri<V> {
+        self
+    }
+}
+
+impl<V> AsRef<[V; 3]> for Tri<V>
+where
+    V: Vertex,
+{
+    fn as_ref(&self) -> &[V; 3] {
+        &self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,13 @@ pub mod audio;
 pub mod color;
 pub mod event;
 mod frame;
-pub mod window;
+pub mod geom;
 pub mod image;
 pub mod math;
 pub mod osc;
 pub mod prelude;
 pub mod ui;
+pub mod window;
 
 pub type ModelFn<Model> = fn(&App) -> Model;
 pub type UpdateFn<Model, Event> = fn(&App, Model, Event) -> Model;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,2 +1,56 @@
 extern crate cgmath;
 pub use self::cgmath::*;
+
+use self::cgmath::num_traits::{NumCast, One};
+use std::ops::Add;
+
+/// Map a value from a given range to a new given range.
+pub fn map_range<X, Y>(val: X, in_min: X, in_max: X, out_min: Y, out_max: Y) -> Y
+where
+    X: NumCast,
+    Y: NumCast,
+{
+    let val_f: f64 = NumCast::from(val).unwrap();
+    let in_min_f: f64 = NumCast::from(in_min).unwrap();
+    let in_max_f: f64 = NumCast::from(in_max).unwrap();
+    let out_min_f: f64 = NumCast::from(out_min).unwrap();
+    let out_max_f: f64 = NumCast::from(out_max).unwrap();
+    NumCast::from(
+        (val_f - in_min_f) / (in_max_f - in_min_f) * (out_max_f - out_min_f) + out_min_f
+    ).unwrap()
+}
+
+/// The max between two partially ordered values.
+pub fn partial_max<T>(a: T, b: T) -> T
+where
+    T: PartialOrd,
+{
+    if a >= b { a } else { b }
+}
+
+/// The min between two partially ordered values.
+pub fn partial_min<T>(a: T, b: T) -> T
+where
+    T: PartialOrd,
+{
+    if a <= b { a } else { b }
+}
+
+/// Clamp a value between some range.
+pub fn clamp<T>(n: T, start: T, end: T) -> T
+where
+    T: PartialOrd,
+{
+    if start <= end {
+        if n < start { start } else if n > end { end } else { n }
+    } else {
+        if n < end { end } else if n > start { start } else { n }
+    }
+}
+
+pub fn two<S>() -> S
+where
+    S: Add<Output=S> + One,
+{
+    S::one() + S::one()
+}


### PR DESCRIPTION
The `geom` module provides efficient functions for describing primitives
via constructs that are commonly useful for graphical representations
such as sequences of points and triangles.

Also adds some more utility functions to the `math` module.

Should be able to use `geom` stuff as a foundation for a graphics API.