### PR TITLE
 Add `state` module for tracking mouse, keyboard and window state.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use audio;
 use audio::cpal;
 use find_folder;
 use glium::glutin;
+use state;
 use std;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -23,10 +24,13 @@ pub struct App {
     pub(crate) events_loop: glutin::EventsLoop,
     pub(crate) windows: RefCell<HashMap<window::Id, Window>>,
     pub(super) exit_on_escape: Cell<bool>,
-    loop_mode: Cell<LoopMode>,
-    /// Audio-related functionality.
-    pub audio: Audio,
     pub(crate) ui: ui::Arrangement,
+    loop_mode: Cell<LoopMode>,
+
+    /// The `App`'s audio-related API.
+    pub audio: Audio,
+    /// The current state of the `Mouse`.
+    pub mouse: state::Mouse,
 }
 
 /// An **App**'s audio API.
@@ -144,6 +148,7 @@ impl App {
         let process_fn_tx = RefCell::new(None);
         let audio = Audio { event_loop: cpal_event_loop, process_fn_tx };
         let ui = ui::Arrangement::new();
+        let mouse = state::Mouse::new();
         App {
             events_loop,
             windows,
@@ -151,6 +156,7 @@ impl App {
             loop_mode,
             audio,
             ui,
+            mouse,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,17 @@ pub struct App {
     pub mouse: state::Mouse,
     /// State of the window currently in focus.
     pub window: state::Window,
+    /// State of the keyboard keys.
+    ///
+    /// `mods` provides state of each of the modifier keys: `shift`, `ctrl`, `alt`, `logo`.
+    ///
+    /// `down` is the set of keys that are currently pressed.
+    ///
+    /// NOTE: `down` this is tracked by the nannou `App` so issues might occur if e.g. a key is
+    /// pressed while the app is in focus and then released when out of focus. Eventually we should
+    /// change this to query the OS somehow, but I don't think `winit` provides a way to do this
+    /// yet.
+    pub keys: state::Keys,
 }
 
 /// An **App**'s audio API.
@@ -153,6 +164,7 @@ impl App {
         let ui = ui::Arrangement::new();
         let mouse = state::Mouse::new();
         let window = state::Window::new();
+        let keys = state::Keys::default();
         App {
             events_loop,
             windows,
@@ -162,6 +174,7 @@ impl App {
             ui,
             mouse,
             window,
+            keys,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,8 +29,11 @@ pub struct App {
 
     /// The `App`'s audio-related API.
     pub audio: Audio,
+
     /// The current state of the `Mouse`.
     pub mouse: state::Mouse,
+    /// State of the window currently in focus.
+    pub window: state::Window,
 }
 
 /// An **App**'s audio API.
@@ -149,6 +152,7 @@ impl App {
         let audio = Audio { event_loop: cpal_event_loop, process_fn_tx };
         let ui = ui::Arrangement::new();
         let mouse = state::Mouse::new();
+        let window = state::Window::new();
         App {
             events_loop,
             windows,
@@ -157,6 +161,7 @@ impl App {
             audio,
             ui,
             mouse,
+            window,
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use window;
 
-pub use glium::glutin::{ElementState, KeyboardInput, MouseButton, MouseScrollDelta, Touch,
-                        TouchPhase, VirtualKeyCode as Key};
+pub use glium::glutin::{ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta,
+                        Touch, TouchPhase, VirtualKeyCode as Key};
 
 /// Event types that are compatible with the nannou app loop.
 pub trait LoopEvent: From<Update> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,20 @@ where
                         app.window.hidpi_factor = hidpi_factor as f64;
                     },
 
+                    glutin::WindowEvent::KeyboardInput { input, .. } => {
+                        app.keys.mods = input.modifiers;
+                        if let Some(key) = input.virtual_keycode {
+                            match input.state {
+                                event::ElementState::Pressed => {
+                                    app.keys.down.keys.insert(key);
+                                },
+                                event::ElementState::Released => {
+                                    app.keys.down.keys.remove(&key);
+                                },
+                            }
+                        }
+                    },
+
                     _ => (),
                 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,34 @@
 pub use self::mouse::Mouse;
+use window;
+
+/// State of the window in focus.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Window {
+    /// ID of the window currently in focus.
+    pub id: Option<window::Id>,
+    /// The width of the focused window agnostic of DPI.
+    ///
+    /// This is equal to the pixel width divided by the hidpi_factor.
+    pub width: f64,
+    /// The height of the focused window agnostic of DPI.
+    ///
+    /// This is equal to the pixel height divided by the hidpi_factor.
+    pub height: f64,
+    /// The high "dots-per-inch" multiplier that describes the density of the screens pixels.
+    pub hidpi_factor: f64,
+}
+
+impl Window {
+    /// Initialise the window state.
+    pub fn new() -> Self {
+        Window {
+            id: None,
+            width: 0.0,
+            height: 0.0,
+            hidpi_factor: 1.0,
+        }
+    }
+}
 
 /// Tracked state related to the mouse.
 pub mod mouse {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,31 +1,66 @@
+pub use self::keys::Keys;
 pub use self::mouse::Mouse;
-use window;
+pub use self::window::Window;
 
-/// State of the window in focus.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Window {
-    /// ID of the window currently in focus.
-    pub id: Option<window::Id>,
-    /// The width of the focused window agnostic of DPI.
-    ///
-    /// This is equal to the pixel width divided by the hidpi_factor.
-    pub width: f64,
-    /// The height of the focused window agnostic of DPI.
-    ///
-    /// This is equal to the pixel height divided by the hidpi_factor.
-    pub height: f64,
-    /// The high "dots-per-inch" multiplier that describes the density of the screens pixels.
-    pub hidpi_factor: f64,
+/// Tracked state related to the focused window.
+pub mod window {
+    use window;
+
+    /// State of the window in focus.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct Window {
+        /// ID of the window currently in focus.
+        pub id: Option<window::Id>,
+        /// The width of the focused window agnostic of DPI.
+        ///
+        /// This is equal to the pixel width divided by the hidpi_factor.
+        pub width: f64,
+        /// The height of the focused window agnostic of DPI.
+        ///
+        /// This is equal to the pixel height divided by the hidpi_factor.
+        pub height: f64,
+        /// The high "dots-per-inch" multiplier that describes the density of the screens pixels.
+        pub hidpi_factor: f64,
+    }
+
+    impl Window {
+        /// Initialise the window state.
+        pub fn new() -> Self {
+            Window {
+                id: None,
+                width: 0.0,
+                height: 0.0,
+                hidpi_factor: 1.0,
+            }
+        }
+    }
 }
 
-impl Window {
-    /// Initialise the window state.
-    pub fn new() -> Self {
-        Window {
-            id: None,
-            width: 0.0,
-            height: 0.0,
-            hidpi_factor: 1.0,
+/// Tracked state related to the keyboard.
+pub mod keys {
+    use event::{Key, ModifiersState};
+    use std::collections::HashSet;
+    use std::ops::Deref;
+
+    /// The state of the keyboard.
+    #[derive(Clone, Debug, Default)]
+    pub struct Keys {
+        /// The state of the modifier keys as last indicated by winit.
+        pub mods: ModifiersState,
+        /// The state of all keys as tracked via the nannou App event handling.
+        pub down: Down,
+    }
+
+    /// The set of keys that are currently pressed.
+    #[derive(Clone, Debug, Default)]
+    pub struct Down {
+        pub(crate) keys: HashSet<Key>,
+    }
+
+    impl Deref for Down {
+        type Target = HashSet<Key>;
+        fn deref(&self) -> &Self::Target {
+            &self.keys
         }
     }
 }
@@ -219,5 +254,4 @@ pub mod mouse {
             Button::Middle => 8,
         }
     }
-
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,7 @@ pub use self::window::Window;
 /// Tracked state related to the focused window.
 pub mod window {
     use window;
+    use math::Vector2;
 
     /// State of the window in focus.
     #[derive(Copy, Clone, Debug, PartialEq)]
@@ -32,6 +33,11 @@ pub mod window {
                 height: 0.0,
                 hidpi_factor: 1.0,
             }
+        }
+
+        /// Return the `width` and `height` as a `Vector2`.
+        pub fn size(&self) -> Vector2<f64> {
+            Vector2 { x: self.width, y: self.height }
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,193 @@
+pub use self::mouse::Mouse;
+
+/// Tracked state related to the mouse.
+pub mod mouse {
+    use math::Point2;
+    use std;
+    use window;
+
+    #[doc(inline)]
+    pub use event::MouseButton as Button;
+
+    /// The max total number of buttons on a mouse.
+    pub const NUM_BUTTONS: usize = 9;
+
+    /// The state of the `Mouse` at a single moment in time.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct Mouse {
+        /// The ID of the last window currently in focus.
+        pub window: Option<window::Id>,
+        /// *x* position relative to the middle of `window`.
+        pub x: f64,
+        /// *y* position relative to the middle of `window`.
+        pub y: f64,
+        /// A map describing the state of each mouse button.
+        pub buttons: ButtonMap,
+    }
+
+    /// Whether the button is up or down.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum ButtonPosition {
+        /// The button is up (i.e. pressed).
+        Up,
+        /// The button is down and was originally pressed down at the given `Point2`.
+        Down(Point2<f64>),
+    }
+
+    /// Stores the state of all mouse buttons.
+    ///
+    /// If the mouse button is down, it stores the position of the mouse when the button was pressed
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct ButtonMap {
+        buttons: [ButtonPosition; NUM_BUTTONS],
+    }
+
+    /// An iterator yielding all pressed buttons.
+    #[derive(Clone)]
+    pub struct PressedButtons<'a> {
+        buttons: std::iter::Enumerate<std::slice::Iter<'a, ButtonPosition>>,
+    }
+
+    impl Mouse {
+        /// Construct a new default `Mouse`.
+        pub fn new() -> Self {
+            Mouse {
+                window: None,
+                buttons: ButtonMap::new(),
+                x: 0.0,
+                y: 0.0,
+            }
+        }
+
+        /// The position of the mouse relative to the middle of the window in focus..
+        pub fn position(&self) -> Point2<f64> {
+            Point2 { x: self.x, y: self.y }
+        }
+    }
+
+    impl ButtonPosition {
+        /// If the mouse button is down, return a new one with position relative to the given `xy`.
+        pub fn relative_to(self, xy: Point2<f64>) -> Self {
+            match self {
+                ButtonPosition::Down(pos) => {
+                    let rel_p = pos - xy;
+                    ButtonPosition::Down(Point2 { x: rel_p.x, y: rel_p.y })
+                }
+                button_pos => button_pos,
+            }
+        }
+
+        /// Is the `ButtonPosition` down.
+        pub fn is_down(&self) -> bool {
+            match *self {
+                ButtonPosition::Down(_) => true,
+                _ => false,
+            }
+        }
+
+        /// Is the `ButtonPosition` up.
+        pub fn is_up(&self) -> bool {
+            match *self {
+                ButtonPosition::Up => true,
+                _ => false,
+            }
+        }
+
+        /// Returns the position at which the button was pressed.
+        pub fn if_down(&self) -> Option<Point2<f64>> {
+            match *self {
+                ButtonPosition::Down(xy) => Some((xy)),
+                _ => None,
+            }
+        }
+    }
+
+    impl ButtonMap {
+        /// Returns a new button map with all states set to `None`
+        pub fn new() -> Self {
+            ButtonMap { buttons: [ButtonPosition::Up; NUM_BUTTONS] }
+        }
+
+        /// Returns a copy of the ButtonMap relative to the given `Point`
+        pub fn relative_to(self, xy: Point2<f64>) -> Self {
+            self.buttons.iter().enumerate().fold(
+                ButtonMap::new(),
+                |mut map,
+                 (idx, button_pos)| {
+                    map.buttons[idx] = button_pos.relative_to(xy);
+                    map
+                },
+            )
+        }
+
+        /// The state of the left mouse button.
+        pub fn left(&self) -> &ButtonPosition {
+            &self[Button::Left]
+        }
+
+        /// The state of the middle mouse button.
+        pub fn middle(&self) -> &ButtonPosition {
+            &self[Button::Middle]
+        }
+
+        /// The state of the right mouse button.
+        pub fn right(&self) -> &ButtonPosition {
+            &self[Button::Right]
+        }
+
+        /// Sets the `Button` in the `Down` position.
+        pub fn press(&mut self, button: Button, xy: Point2<f64>) {
+            self.buttons[button_to_idx(button)] = ButtonPosition::Down(xy);
+        }
+
+        /// Set's the `Button` in the `Up` position.
+        pub fn release(&mut self, button: Button) {
+            self.buttons[button_to_idx(button)] = ButtonPosition::Up;
+        }
+
+        /// An iterator yielding all pressed mouse buttons along with the location at which they
+        /// were originally pressed.
+        pub fn pressed(&self) -> PressedButtons {
+            PressedButtons { buttons: self.buttons.iter().enumerate() }
+        }
+    }
+
+    impl std::ops::Index<Button> for ButtonMap {
+        type Output = ButtonPosition;
+        fn index(&self, button: Button) -> &Self::Output {
+            &self.buttons[button_to_idx(button)]
+        }
+    }
+
+    impl<'a> Iterator for PressedButtons<'a> {
+        type Item = (Button, Point2<f64>);
+        fn next(&mut self) -> Option<Self::Item> {
+            while let Some((idx, button_pos)) = self.buttons.next() {
+                if let ButtonPosition::Down(xy) = *button_pos {
+                    return Some((idx_to_button(idx), xy));
+                }
+            }
+            None
+        }
+    }
+
+    fn idx_to_button(i: usize) -> Button {
+        match i {
+            n @ 0...5 => Button::Other(n as u8),
+            6 => Button::Left,
+            7 => Button::Right,
+            8 => Button::Middle,
+            _ => Button::Other(std::u8::MAX),
+        }
+    }
+
+    fn button_to_idx(button: Button) -> usize {
+        match button {
+            Button::Other(n) => n as usize,
+            Button::Left => 6,
+            Button::Right => 7,
+            Button::Middle => 8,
+        }
+    }
+
+}


### PR DESCRIPTION
Only `Mouse` and `Window` state tracking is implemented so far.

Tracked mouse state includes mouse position, window in focus and pressed buttons.

Tracked window state includes width, height, ID and hidpi_factor of window currently in focus.

Tracked keyboard state includes a set of pressed keys and the state of each of the modifier keys.

**Usage Examples**

Mouse
```
let x = app.mouse.x;
if app.mouse.buttons.left().is_down() {
    // do something
}
let p = app.mouse.position();
```
Window
```
let w = app.window.width;
if app.window.id == my_window {
    // do something
}
let size = app.window.size();
```
Keyboard
```
if app.keys.mods.ctrl {
    // do something
}
if app.keys.down.contains(&Key::Space) || app.keys.down.contains(&Key::Enter) {
    // do something if space or enter is down
}
```

Closes #53.
Closes #52.

cc @JoshuaBatty got some state tracking happening :+1: