### PR TITLE
Expose helper Vector and Point constructors in prelude

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -4,6 +4,18 @@ pub use self::cgmath::*;
 use self::cgmath::num_traits::{NumCast, One};
 use std::ops::Add;
 
+pub fn pt1<S>(x: S) -> Point1<S> {
+    Point1 { x }
+}
+
+pub fn pt2<S>(x: S, y: S) -> Point2<S> {
+    Point2 { x, y }
+}
+
+pub fn pt3<S>(x: S, y: S, z: S) -> Point3<S> {
+    Point3 { x, y, z }
+}
+
 /// Map a value from a given range to a new given range.
 pub fn map_range<X, Y>(val: X, in_min: X, in_max: X, out_min: Y, out_max: Y) -> Y
 where

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,6 @@ pub use app::{App, LoopMode};
 pub use event::SimpleWindowEvent::*;
 pub use event::{Event, Key};
 pub use frame::Frame;
-pub use math::{Point2, Point3, Vector2, Vector3, vec2, vec3};
+pub use math::{Point2, Point3, Vector2, Vector3, vec1, vec2, vec3, vec4, pt1, pt2, pt3};
 pub use math::prelude::*;
 pub use window::Id as WindowId;


### PR DESCRIPTION
Closes #56.

We can now make points using `pt2(x, y)`, `pt3(x, y, z)`, `vec3(x, y, z)`, etc, each of which are provided via the prelude.

cc @JoshuaBatty.