### PR TITLE
 Add a `geom::Graph` for composing together geometric primitives (along with other `Graph`s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ repository = "https://github.com/MindBuffer/nannou.git"
 homepage = "https://github.com/MindBuffer/nannou"
 
 [dependencies]
-cgmath = { version = "0.15", features = ["serde"] }
+cgmath = { version = "0.16", features = ["serde"] }
 conrod = { version = "0.58", features = ["winit", "glium"] }
 cpal = "0.8"
+daggy = "0.6"
 find_folder = "0.3"
 glium = "0.20"
 image = "0.18"

--- a/src/geom/ellipse.rs
+++ b/src/geom/ellipse.rs
@@ -4,11 +4,31 @@ use math::num_traits::{Float, NumCast};
 use std;
 use std::ops::Neg;
 
+/// A simple ellipse type with helper methods around the `ellipse` module's functions.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Ellipse<S = f64> {
+    /// The width and height off the `Ellipse`.
+    pub rect: Rect<S>,
+    /// The resolution (number of sides) of the `Ellipse`.
+    pub resolution: usize,
+}
+
+/// A subsection of an `Ellipse`.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Section<S = f64> {
+    /// The ellipse from which this section is produced.
+    pub ellipse: Ellipse<S>,
+    /// The angle in radians of the start of the section.
+    pub offset_radians: S,
+    /// The section of the circumference in radians.
+    pub section_radians: S,
+}
+
 /// An iterator yielding the edges of an ellipse (or some section of an `ellipse`) as a series of
 /// points.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[allow(missing_copy_implementations)]
-pub struct Circumference<S> {
+pub struct Circumference<S = f64> {
     index: usize,
     num_points: usize,
     point: Point2<S>,
@@ -19,12 +39,73 @@ pub struct Circumference<S> {
 }
 
 /// An iterator yielding triangles that describe an oval or some section of an oval.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Triangles<S> {
     // The last circumference point yielded by the `CircumferenceOffset` iterator.
     last: Point2<S>,
     // The circumference points used to yield yielded by the `CircumferenceOffset` iterator.
     points: Circumference<S>,
+}
+
+impl<S> Ellipse<S>
+where
+    S: BaseNum + Neg<Output=S>,
+{
+    /// Construct a new ellipse from its bounding rect and resolution (number of sides).
+    pub fn new(rect: Rect<S>, resolution: usize) -> Self {
+        Ellipse { rect, resolution }
+    }
+
+    /// A section of the `Ellipse`.
+    ///
+    /// `offset_radians` describes the angle at which the offset begins.
+    ///
+    /// `section_radians` describes how large the section is as an angle.
+    pub fn section(self, offset_radians: S, section_radians: S) -> Section<S> {
+        Section {
+            ellipse: self,
+            offset_radians,
+            section_radians,
+        }
+    }
+
+    /// Produces an iterator yielding the points of the ellipse circumference.
+    pub fn circumference(self) -> Circumference<S> {
+        let Ellipse { rect, resolution } = self;
+        Circumference::new(rect, resolution)
+    }
+
+    /// Produces an iterator yielding the triangles that describe the ellipse.
+    ///
+    /// TODO: Describe the order.
+    pub fn triangles(self) -> Triangles<S>
+    where
+        S: Float,
+    {
+        self.circumference().triangles()
+    }
+}
+
+impl<S> Section<S>
+where
+    S: BaseNum + Neg<Output=S>,
+{
+    /// Produces an iterator yielding the points of the ellipse circumference.
+    pub fn circumference(self) -> Circumference<S> {
+        let Section { ellipse, offset_radians, section_radians } = self;
+        let circ = Circumference::new_section(ellipse.rect, ellipse.resolution, section_radians);
+        circ.offset_radians(offset_radians)
+    }
+
+    /// Produces an iterator yielding the triangles that describe the ellipse section.
+    ///
+    /// TODO: Describe the order.
+    pub fn trangles(self) -> Triangles<S>
+    where
+        S: Float,
+    {
+        self.circumference().triangles()
+    }
 }
 
 impl<S> Circumference<S>
@@ -125,6 +206,27 @@ where
         *index += 1;
         Some([x, y].into())
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+// TODO:
+// impl<S> DoubleEndedIterator for Circumference<S>
+// where
+//     S: BaseNum + Float,
+// {
+// }
+
+impl<S> ExactSizeIterator for Circumference<S>
+where
+    S: BaseNum + Float,
+{
+    fn len(&self) -> usize {
+        self.num_points - self.index
+    }
 }
 
 impl<S> Iterator for Triangles<S>
@@ -139,5 +241,19 @@ where
             *last = next;
             triangle
         })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<S> ExactSizeIterator for Triangles<S>
+where
+    S: BaseNum + Float,
+{
+    fn len(&self) -> usize {
+        self.points.len()
     }
 }

--- a/src/geom/graph/edge.rs
+++ b/src/geom/graph/edge.rs
@@ -1,0 +1,189 @@
+//! Items related to the edges of a geometry graph.
+use daggy;
+
+/// Unique index for an **Edge** within a **Graph**.
+pub type Index = daggy::EdgeIndex<usize>;
+
+/// An iterator yielding multiple `Index`es.
+pub type Indices = daggy::EdgeIndices<usize>;
+
+/// Describes an edge within the geometry graph.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Edge<S> {
+    /// The unique kind of edge.
+    ///
+    /// Represents the combination of `Axis` and `Relative` association described by the edge.
+    pub kind: Kind,
+    /// A weight whose value's meaning depends on the edge's `Relative` association.
+    ///
+    /// For `Position` kind edges this represents a relative scalar value.
+    /// For `Orientation` kind edges this represents a relative angle in radians.
+    /// For `Scale` kind edges this represents the relative scale.
+    pub weight: S,
+}
+
+/// The unique `Edge` kind - a combo of a `Relative` association and an `Axis`.
+///
+/// Every incoming (parent) `Edge` for each `Node` in the graph *must* be a unique kind. E.g.
+/// it does not make sense for a `Node` to be positioned relatively along the *x* axis to two
+/// different parent `Node`s.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Kind {
+    /// The axis along which this edge describes some relationship.
+    pub axis: Axis,
+    /// The relative association described by the edge.
+    pub relative: Relative,
+}
+
+/// Describes one of the three axes in three-dimensional space.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+/// The various possible relative relationships that can be created between nodes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Relative {
+    /// A relative position as a scalar value.
+    Position,
+    /// A relative orientation in radians.
+    Orientation,
+    /// A relative scale.
+    Scale,
+}
+
+impl Kind {
+    /// Simple constructor for an edge `Kind`.
+    pub fn new(axis: Axis, relative: Relative) -> Self {
+        Kind { axis, relative }
+    }
+
+    /// Simple constructor for and Edge describing a relative association over the **X** axis.
+    pub fn x(relative: Relative) -> Self {
+        Kind::new(Axis::X, relative)
+    }
+
+    /// Simple constructor for and Edge describing a relative association over the **Y** axis.
+    pub fn y(relative: Relative) -> Self {
+        Kind::new(Axis::Y, relative)
+    }
+
+    /// Simple constructor for and Edge describing a relative association over the **Z** axis.
+    pub fn z(relative: Relative) -> Self {
+        Kind::new(Axis::Z, relative)
+    }
+
+    /// Simple constructor for and Edge describing a relative position over the **X** axis.
+    pub fn x_position() -> Self {
+        Kind::x(Relative::Position)
+    }
+
+    /// Simple constructor for and Edge describing a relative orientation over the **X** axis.
+    pub fn x_orientation() -> Self {
+        Kind::x(Relative::Orientation)
+    }
+
+    /// Simple constructor for and Edge describing a relative scale over the **X** axis.
+    pub fn x_scale() -> Self {
+        Kind::x(Relative::Scale)
+    }
+
+    /// Simple constructor for and Edge describing a relative position over the **Y** axis.
+    pub fn y_position() -> Self {
+        Kind::y(Relative::Position)
+    }
+
+    /// Simple constructor for and Edge describing a relative orientation over the **Y** axis.
+    pub fn y_orientation() -> Self {
+        Kind::y(Relative::Orientation)
+    }
+
+    /// Simple constructor for and Edge describing a relative scale over the **Y** axis.
+    pub fn y_scale() -> Self {
+        Kind::y(Relative::Scale)
+    }
+
+    /// Simple constructor for and Edge describing a relative position over the **Z** axis.
+    pub fn z_position() -> Self {
+        Kind::z(Relative::Position)
+    }
+
+    /// Simple constructor for and Edge describing a relative orientation over the **Z** axis.
+    pub fn z_orientation() -> Self {
+        Kind::z(Relative::Orientation)
+    }
+
+    /// Simple constructor for and Edge describing a relative scale over the **Z** axis.
+    pub fn z_scale() -> Self {
+        Kind::z(Relative::Scale)
+    }
+}
+
+impl<S> Edge<S> {
+    /// Simple constructor for an `Edge`.
+    pub fn new(kind: Kind, weight: S) -> Self {
+        Edge { kind, weight }
+    }
+
+    /// Simple constructor for an `Edge` describing a relative association over the **X** axis.
+    pub fn x(relative: Relative, weight: S) -> Self {
+        Edge::new(Kind::x(relative), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative association over the **Y** axis.
+    pub fn y(relative: Relative, weight: S) -> Self {
+        Edge::new(Kind::y(relative), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative association over the **Z** axis.
+    pub fn z(relative: Relative, weight: S) -> Self {
+        Edge::new(Kind::z(relative), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative position over the **X** axis.
+    pub fn x_position(weight: S) -> Self {
+        Edge::new(Kind::x_position(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative orientation over the **X** axis.
+    pub fn x_orientation(weight: S) -> Self {
+        Edge::new(Kind::x_orientation(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative scale over the **X** axis.
+    pub fn x_scale(weight: S) -> Self {
+        Edge::new(Kind::x_scale(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative position over the **Y** axis.
+    pub fn y_position(weight: S) -> Self {
+        Edge::new(Kind::y_position(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative orientation over the **Y** axis.
+    pub fn y_orientation(weight: S) -> Self {
+        Edge::new(Kind::y_orientation(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative scale over the **Y** axis.
+    pub fn y_scale(weight: S) -> Self {
+        Edge::new(Kind::y_scale(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative position over the **Z** axis.
+    pub fn z_position(weight: S) -> Self {
+        Edge::new(Kind::z_position(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative orientation over the **Z** axis.
+    pub fn z_orientation(weight: S) -> Self {
+        Edge::new(Kind::z_orientation(), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative scale over the **Z** axis.
+    pub fn z_scale(weight: S) -> Self {
+        Edge::new(Kind::z_scale(), weight)
+    }
+}

--- a/src/geom/graph/mod.rs
+++ b/src/geom/graph/mod.rs
@@ -1,0 +1,716 @@
+use daggy::{self, Walker};
+use daggy::petgraph::visit::{GraphBase, IntoNeighbors, Visitable};
+use geom::{self, DefaultScalar};
+use math::{BaseFloat, Point3};
+use std::iter;
+use std::ops;
+use std::option;
+
+pub use self::edge::Edge;
+pub use self::node::Node;
+
+pub mod edge;
+pub mod node;
+
+/// A composition of primitive geometry described by an acyclic directed graph.
+///
+/// The `Node`s within a graph may describe some primitive geometry (e.g. `Line`, `Cuboid`, etc) or
+/// may contain other `Graph`s. This allows graphs to be composed of other graphs, which may then
+/// be composed with other graphs, etc.
+///
+/// The `Edge`s within a graph describe the relationships between the nodes. They allow for
+/// describing the **position**, **orientation** and **scale** of nodes relative to others.
+///
+/// All `Node`s other than the graph's "origin" node must have at least one parent, but may never
+/// have more than one parent of each `edge::Kind`.
+///
+/// The `Graph` is made up of three primary internal `Vec`s:
+///
+/// 1. The node `Vec` containing all `Node`s.
+/// 2. The edge `Vec` containing all `Edge`s.
+/// 3. The vertices `Vec` containing all vertices for all primitives that may be described by a
+///    dynamic number of vertices.
+#[derive(Clone, Debug)]
+pub struct Graph<S>
+where
+    S: BaseFloat,
+{
+    dag: Dag<S>,
+    vertices: Vec<Point3<S>>,
+    origin: node::Index,
+}
+
+/// The `daggy` "directed acyclic graph" type used within the geometry graph.
+pub type Dag<S> = daggy::Dag<Node<S>, Edge<S>, usize>;
+
+/// A **Walker** over some node's parent nodes.
+pub struct Parents<S>
+where
+    S: BaseFloat,
+{
+    parents: daggy::Parents<Node<S>, Edge<S>, usize>,
+}
+
+/// A **Walker** over some node's children nodes.
+pub struct Children<S>
+where
+    S: BaseFloat,
+{
+    children: daggy::Children<Node<S>, Edge<S>, usize>,
+}
+
+/// The slice of all nodes stored within the graph.
+pub type RawNodes<'a, S> = daggy::RawNodes<'a, Node<S>, usize>;
+
+/// The slice of all edges stored within the graph.
+pub type RawEdges<'a, S> = daggy::RawEdges<'a, Edge<S>, usize>;
+
+/// An alias for our Graph's **WouldCycle** error type.
+pub type WouldCycle<S> = daggy::WouldCycle<Edge<S>>;
+
+/// An alias for our Graph's recursive walker.
+pub type RecursiveWalk<S, F> = daggy::walker::Recursive<Graph<S>, F>;
+
+// An alias for the iterator yielding three parents that may or may not exist.
+//
+// Used for the `Position`, `Orientation` and `Scale` parents.
+type ThreeNodes = iter::Chain<
+    iter::Chain<option::IntoIter<node::Index>, option::IntoIter<node::Index>>,
+    option::IntoIter<node::Index>,
+>;
+
+/// An alias for the iterator yielding **X**, **Y** and **Z** **Position** parents.
+pub type PositionParents = ThreeNodes;
+/// An alias for the iterator yielding **X**, **Y** and **Z** **Orientation** parents.
+pub type OrientationParents = ThreeNodes;
+/// An alias for the iterator yielding **X**, **Y** and **Z** **Scale** parents.
+pub type ScaleParents = ThreeNodes;
+/// An alias for the iterator yielding **Position**, **Orientation** and **Scale** parents over the
+/// **X** axis.
+pub type XParents = ThreeNodes;
+/// An alias for the iterator yielding **Position**, **Orientation** and **Scale** parents over the
+/// **Y** axis.
+pub type YParents = ThreeNodes;
+/// An alias for the iterator yielding **Position**, **Orientation** and **Scale** parents over the
+/// **Z** axis.
+pub type ZParents = ThreeNodes;
+
+/// A **Walker** type yielding all transformed vertices of all nodes within the graph.
+// TODO: Rewrite these to use a new `node::WalkTransformedVertices` walker type
+pub struct WalkVertices<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    dfs: &'a mut node::Dfs<S>,
+    node: node::TransformedVertices<'a, S>,
+}
+
+/// A **Walker** type yielding all transformed triangles of all nodes within the graph.
+// TODO: Rewrite these to use a new `node::WalkTransformedTriangles` walker type
+pub struct WalkTriangles<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    dfs: &'a mut node::Dfs<S>,
+    node: Option<node::TransformedTriangles<'a, S>>,
+}
+
+/// An iterator yielding all vertices of all nodes within the graph.
+///
+/// Uses the `WalkVertices` internally.
+pub struct Vertices<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    graph: &'a Graph<S>,
+    walker: Box<WalkVertices<'a, S>>,
+}
+
+/// An iterator yielding all triangles of all nodes within the graph.
+///
+/// Uses the `WalkTriangles` internally.
+pub struct Triangles<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    graph: &'a Graph<S>,
+    walker: Box<WalkTriangles<'a, S>>,
+}
+
+impl<'a, S> WalkVertices<'a, S>
+where
+    S: BaseFloat,
+{
+    /// Return the next vertex in the graph.
+    pub fn next(&mut self, graph: &'a Graph<S>) -> Option<Point3<S>> {
+        loop {
+            if let Some(v) = self.node.next() {
+                return Some(v);
+            }
+            match self.dfs.next_vertices(graph) {
+                Some((_n, vs)) => self.node = vs,
+                None => return None,
+            }
+        }
+    }
+}
+
+impl<'a, S> WalkTriangles<'a, S>
+where
+    S: BaseFloat,
+{
+    /// Return the next vertex in the graph.
+    pub fn next(&mut self, graph: &'a Graph<S>) -> Option<geom::Tri<Point3<S>>> {
+        loop {
+            if let Some(v) = self.node.as_mut().and_then(|n| n.next()) {
+                return Some(v);
+            }
+            match self.dfs.next_triangles(graph) {
+                Some((_n, ts)) => self.node = Some(ts),
+                None => return None,
+            }
+        }
+    }
+}
+
+impl<'a, S> Iterator for Vertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = Point3<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.walker.next(self.graph)
+    }
+}
+
+impl<'a, S> Iterator for Triangles<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = geom::Tri<Point3<S>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.walker.next(self.graph)
+    }
+}
+
+impl<S> Graph<S>
+where
+    S: BaseFloat,
+{
+    /// Construct a new empty `Graph` with a single "origin" node.
+    ///
+    /// The "origin" is the "parent-most" of all nodes. Its transform is always equal to
+    /// `Transform::default()`.
+    ///
+    /// Calling this is the same as calling `Graph::default()`.
+    pub fn new() -> Self {
+        Graph::default()
+    }
+
+    /// The **node::Index** of the origin node.
+    pub fn origin(&self) -> node::Index {
+        self.origin
+    }
+
+    /// A view of the raw vertex slice, used for primitives with a dynamic number of vertices.
+    pub fn raw_vertices(&self) -> &[Point3<S>] {
+        &self.vertices[..]
+    }
+
+    /// Construct the graph with pre-allocated buffers for the given `nodes`, `edges` and
+    /// `vertices` capacities.
+    pub fn with_capacity(nodes: usize, edges: usize, vertices: usize) -> Self {
+        let mut dag = Dag::with_capacity(nodes, edges);
+        let origin = dag.add_node(Node::Point);
+        let vertices = Vec::with_capacity(vertices);
+        Graph { dag, vertices, origin }
+    }
+
+    /// The total number of **Node**s in the **Graph**.
+    pub fn node_count(&self) -> usize {
+        self.dag.node_count()
+    }
+
+    /// The total number of **Edge**s in the **Graph**.
+    pub fn edge_count(&self) -> usize {
+        self.dag.edge_count()
+    }
+
+    /// The number of vertices stored for all primitives.
+    ///
+    /// This is sometimes useful for reasoning about the possible use of `with_capacity`.
+    pub fn vertex_count(&self) -> usize {
+        self.vertices.len()
+    }
+
+    /// Borrow the node at the given **node::Index** if there is one.
+    pub fn node(&self, idx: node::Index) -> Option<&Node<S>> {
+        self.dag.node_weight(idx)
+    }
+
+    /// Borrow the edge at the given **edge::Index** if there is one.
+    pub fn edge(&self, idx: edge::Index) -> Option<&Edge<S>> {
+        self.dag.edge_weight(idx)
+    }
+
+    /// The slice containing all nodes.
+    pub fn raw_nodes(&self) -> RawNodes<S> {
+        self.dag.raw_nodes()
+    }
+
+    /// The slice containing all edges.
+    pub fn raw_edges(&self) -> RawEdges<S> {
+        self.dag.raw_edges()
+    }
+
+    /// The `Cuboid` that bounds all nodes within the geometry graph.
+    ///
+    /// Returns `None` if the graph contains no vertices.
+    ///
+    /// 1. Iterates over all nodes.
+    /// 2. Expands a cuboid to the max bounds of each node.
+    /// 3. Returns the resulting cuboid.
+    pub fn bounding_cuboid(&self) -> Option<geom::Cuboid<S>> {
+        let mut node_bounds = self.raw_nodes()
+            .iter()
+            .filter_map(|node| node.weight.bounding_cuboid(&self.vertices));
+        node_bounds.next()
+            .map(|bounds| node_bounds.fold(bounds, geom::Cuboid::max))
+    }
+
+    /// Removes all **Node**s, **Edge**s and vertices from the **Graph**.
+    ///
+    /// This does not de-allocate any buffers and should retain capacity. To drop all inner
+    /// buffers, use `mem::replace` with a new empty **Graph**.
+    pub fn clear(&mut self) {
+        self.dag.clear()
+    }
+
+    /// Return the parent and child nodes on either end of the **Edge** at the given index.
+    pub fn edge_endpoints(&self, idx: edge::Index) -> Option<(node::Index, node::Index)> {
+        self.dag.edge_endpoints(idx)
+    }
+
+    /// A **Walker** type that recursively walks the **Graph** using the given `recursive_fn`.
+    ///
+    /// **Panics** If the given start index does not exist within the **Graph**.
+    pub fn recursive_walk<F>(&self, start: node::Index, recursive_fn: F) -> RecursiveWalk<S, F>
+    where
+        F: FnMut(&Self, node::Index) -> Option<(edge::Index, node::Index)>,
+    {
+        RecursiveWalk::new(start, recursive_fn)
+    }
+
+    /// Borrow the inner `daggy::Dag` (directed acyclic graph) upon which `Graph` is built.
+    ///
+    /// Can be useful/necessary for utilising some of the `daggy::Walker` types.
+    pub fn dag(&self) -> &Dag<S> {
+        &self.dag
+    }
+
+    // Add the given **Node** to the graph.
+    //
+    // Computes in **O(1)** time.
+    //
+    // Returns the index of the new node.
+    fn add_node(&mut self, node: Node<S>) -> node::Index {
+        self.dag.add_node(node)
+    }
+
+    // Remove and return the **Edge** at the given index.
+    //
+    // Return `None` if it didn't exist.
+    fn remove_edge(&mut self, idx: edge::Index) -> Option<Edge<S>> {
+        self.dag.remove_edge(idx)
+    }
+
+    /// Set the given **Edge** within the graph.
+    ///
+    /// The added edge will be in the direction `a` -> `b`
+    ///
+    /// There may only ever be one **Edge** of the given variant between `a` -> `b`.
+    ///
+    /// Checks if the edge would create a cycle in the **Graph**.
+    ///
+    /// If adding the edge **would not** cause the graph to cycle, the edge will be added and its
+    /// `edge::Index` returned.
+    ///
+    /// If adding the edge **would** cause the graph to cycle, the edge will not be added and
+    /// instead a `WouldCycle` error with the given weight will be returned.
+    ///
+    /// **Panics** if either `a` or `b` do not exist within the **Graph**.
+    ///
+    /// **Panics** if the **Graph** is at the maximum number of nodes for its index type.
+    pub fn set_edge(
+        &mut self,
+        a: node::Index,
+        b: node::Index,
+        edge: Edge<S>,
+    ) -> Result<edge::Index, WouldCycle<S>> {
+        // Check to see if the node already has some matching incoming edge.
+        // Keep it if it's the one we want. Otherwise, remove any incoming edge that matches the given
+        // edge kind but isn't coming from the node that we desire.
+        let mut parents = self.parents(b);
+        let mut already_set = None;
+
+        while let Some((in_edge_idx, in_node_idx)) = parents.walk_next(self) {
+            if edge.kind == self[in_edge_idx].kind {
+                if in_node_idx == a {
+                    already_set = Some(in_edge_idx);
+                } else {
+                    self.remove_edge(in_edge_idx);
+                }
+                // Note that we only need to check for *one* edge as there can only ever be one
+                // parent edge of any kind for each node. We know this, as this method is the only
+                // function used by a public method that adds edges.
+                break;
+            }
+        }
+
+        // If we don't already have an incoming edge from the requested parent, add one.
+        match already_set {
+            Some(edge_idx) => Ok(edge_idx),
+            None => self.dag.add_edge(a, b, edge),
+        }
+    }
+
+    /// Add the given node as a child to the given `parent` connected via the given edges.
+    ///
+    /// There may only ever be one **Edge** of the given variant between `a` -> `b`.
+    ///
+    /// **Panics** if:
+    ///
+    /// - `parent` does not exist within the **Graph**.
+    /// - `edges` does not contain at least one **Edge<S>**.
+    /// - the **Graph** is at the maximum number of nodes for its index type.
+    pub fn add_child<E>(
+        &mut self,
+        parent: node::Index,
+        edges: E,
+        node: Node<S>,
+    ) -> (edge::Indices, node::Index)
+    where
+        E: IntoIterator<Item = Edge<S>>,
+    {
+        let n = self.add_node(node);
+        let mut edges = edges.into_iter().peekable();
+        match edges.next() {
+            None => panic!("`edges` must contain at least one edge"),
+            Some(first) => {
+                let edges = Some(first).into_iter()
+                    .chain(edges)
+                    .map(|e| (parent, n, e));
+                let edge_indices = self.dag
+                    .add_edges(edges)
+                    .expect("cannot create a cycle when adding a new child");
+                (edge_indices, n)
+            },
+        }
+    }
+
+    /// Add the given children to the given `parent` connected via the given edges for each child.
+    ///
+    /// Returns an iterator yielding the node and edge indices for each child that was added.
+    ///
+    /// There may only ever be one **Edge** of the given variant between `a` -> `b`.
+    ///
+    /// **Panics** if:
+    ///
+    /// - `parent` does not exist within the **Graph**.
+    /// - any of the child `edges` iterators do not contain at least one **Edge<S>**.
+    /// - the **Graph** is at the maximum number of nodes for its index type.
+    pub fn add_children<C, E>(
+        &mut self,
+        parent: node::Index,
+        children: C,
+    ) -> Vec<(edge::Indices, node::Index)>
+    where
+        C: IntoIterator<Item = (E, Node<S>)>,
+        E: IntoIterator<Item = Edge<S>>,
+    {
+        let mut children_indices = vec![];
+        for (edges, node) in children {
+            let child_indices = self.add_child(parent, edges, node);
+            children_indices.push(child_indices);
+        }
+        children_indices
+    }
+
+    // Produce a walker yielding all vertices from all nodes within the graph in order of
+    // discovery within a depth-first-search.
+    // TODO: Remove the lifetime from self (only need DFS after WalkTransformedVertices is added)
+    // and make this public.
+    fn walk_vertices<'a>(&'a self, dfs: &'a mut node::Dfs<S>) -> WalkVertices<'a, S> {
+        let (_, node) = dfs.next_vertices(self).unwrap();
+        WalkVertices { dfs, node }
+    }
+
+    // Produce a walker yielding all vertices from all nodes within the graph in order of
+    // discovery within a depth-first-search.
+    // TODO: Remove the lifetime from self (only need DFS after WalkTransformedVertices is added)
+    // and make this public.
+    fn walk_triangles<'a>(&'a self, dfs: &'a mut node::Dfs<S>) -> WalkTriangles<'a, S> {
+        let node = dfs.next_triangles(self).map(|(_, node)| node);
+        WalkTriangles { dfs, node }
+    }
+
+    /// Produce an iterator yielding all vertices from all nodes within the graph in order of
+    /// discovery within a depth-first-search.
+    pub fn vertices<'a>(&'a self, dfs: &'a mut node::Dfs<S>) -> Vertices<'a, S> {
+        let walker = Box::new(self.walk_vertices(dfs));
+        Vertices { graph: self, walker }
+    }
+
+    /// Produce an iterator yielding all triangles from all nodes within the graph in order of
+    /// discovery within a depth-first-search.
+    pub fn triangles<'a>(&'a self, dfs: &'a mut node::Dfs<S>) -> Triangles<'a, S> {
+        let walker = Box::new(self.walk_triangles(dfs));
+        Triangles { graph: self, walker }
+    }
+
+    // TODO:
+    //
+    // - `set_edges`: take an `IntoIterator<Item=Edge>` (or perhaps more flexible (IntoEdges).
+    // - `add_child`: public facing way of adding nodes along with an initial edge.
+    // - `add_children`
+    // - Methods for adding nodes with `scale`, etc methods that do all axes at once.
+
+    //---------------
+    // PARENT METHODS
+    //---------------
+
+    /// A **Walker** type that may be used to step through the parents of the given child node.
+    pub fn parents(&self, child: node::Index) -> Parents<S> {
+        let parents = self.dag.parents(child);
+        Parents { parents }
+    }
+
+    /// If the **Node** at the given index has some parent along an **Edge** of the given variant,
+    /// return an index to it.
+    pub fn edge_parent(&self, idx: node::Index, edge: edge::Kind) -> Option<node::Index> {
+        self.parents(idx)
+            .iter(self)
+            .find(|&(e, _)| self[e].kind == edge)
+            .map(|(_, n)| n)
+    }
+
+    /// Return the index of the parent along the given node's **Position** **Edge**.
+    pub fn position_parent(&self, idx: node::Index, axis: edge::Axis) -> Option<node::Index> {
+        let kind = edge::Kind::new(axis, edge::Relative::Position);
+        self.edge_parent(idx, kind)
+    }
+
+    /// Return the index of the parent along the given node's **Position** **Edge**.
+    pub fn x_position_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.position_parent(idx, edge::Axis::X)
+    }
+
+    /// Return the index of the parent along the given node's **Position** **Edge**.
+    pub fn y_position_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.position_parent(idx, edge::Axis::Y)
+    }
+
+    /// Return the index of the parent along the given node's **Position** **Edge**.
+    pub fn z_position_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.position_parent(idx, edge::Axis::Z)
+    }
+
+    /// Produce an **Iterator** yielding the **Position** parents to the given node.
+    ///
+    /// Parents are always yielded in order of axis, e.g. **X**, **Y** then **Z**.
+    pub fn position_parents(&self, idx: node::Index) -> PositionParents {
+        self.x_position_parent(idx)
+            .into_iter()
+            .chain(self.y_position_parent(idx))
+            .chain(self.z_position_parent(idx))
+    }
+
+    /// Return the index of the parent along the given node's **Orientation** **Edge**.
+    pub fn orientation_parent(&self, idx: node::Index, axis: edge::Axis) -> Option<node::Index> {
+        let kind = edge::Kind::new(axis, edge::Relative::Orientation);
+        self.edge_parent(idx, kind)
+    }
+
+    /// Return the index of the parent along the given node's **Orientation** **Edge**.
+    pub fn x_orientation_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.orientation_parent(idx, edge::Axis::X)
+    }
+
+    /// Return the index of the parent along the given node's **Orientation** **Edge**.
+    pub fn y_orientation_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.orientation_parent(idx, edge::Axis::Y)
+    }
+
+    /// Return the index of the parent along the given node's **Orientation** **Edge**.
+    pub fn z_orientation_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.orientation_parent(idx, edge::Axis::Z)
+    }
+
+    /// Produce an **Iterator** yielding the **Orientation** parents to the given node.
+    ///
+    /// Parents are always yielded in order of axis, e.g. **X**, **Y** then **Z**.
+    pub fn orientation_parents(&self, idx: node::Index) -> OrientationParents {
+        self.x_orientation_parent(idx)
+            .into_iter()
+            .chain(self.y_orientation_parent(idx))
+            .chain(self.z_orientation_parent(idx))
+    }
+
+    /// Return the index of the parent along the given node's **Scale** **Edge**.
+    pub fn scale_parent(&self, idx: node::Index, axis: edge::Axis) -> Option<node::Index> {
+        let kind = edge::Kind::new(axis, edge::Relative::Scale);
+        self.edge_parent(idx, kind)
+    }
+
+    /// Return the index of the parent along the given node's **Scale** **Edge**.
+    pub fn x_scale_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.scale_parent(idx, edge::Axis::X)
+    }
+
+    /// Return the index of the parent along the given node's **Scale** **Edge**.
+    pub fn y_scale_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.scale_parent(idx, edge::Axis::Y)
+    }
+
+    /// Return the index of the parent along the given node's **Scale** **Edge**.
+    pub fn z_scale_parent(&self, idx: node::Index) -> Option<node::Index> {
+        self.scale_parent(idx, edge::Axis::Z)
+    }
+
+    /// Produce an **Iterator** yielding the **Scale** parents to the given node.
+    ///
+    /// Parents are always yielded in order of axis, e.g. **X**, **Y** then **Z**.
+    pub fn scale_parents(&self, idx: node::Index) -> ScaleParents {
+        self.x_scale_parent(idx)
+            .into_iter()
+            .chain(self.y_scale_parent(idx))
+            .chain(self.z_scale_parent(idx))
+    }
+
+    /// Produce an **Iterator** yielding the **X** parents to the given node.
+    ///
+    /// Parents are always yielded in order of **Position**, **Orientation** and **Scale**.
+    pub fn x_parents(&self, idx: node::Index) -> XParents {
+        self.x_position_parent(idx)
+            .into_iter()
+            .chain(self.x_orientation_parent(idx))
+            .chain(self.x_scale_parent(idx))
+    }
+
+    /// Produce an **Iterator** yielding the **Y** parents to the given node.
+    ///
+    /// Parents are always yielded in order of **Position**, **Orientation** and **Scale**.
+    pub fn y_parents(&self, idx: node::Index) -> YParents {
+        self.y_position_parent(idx)
+            .into_iter()
+            .chain(self.y_orientation_parent(idx))
+            .chain(self.y_scale_parent(idx))
+    }
+
+    /// Produce an **Iterator** yielding the **Z** parents to the given node.
+    ///
+    /// Parents are always yielded in order of **Position**, **Orientation** and **Scale**.
+    pub fn z_parents(&self, idx: node::Index) -> ZParents {
+        self.z_position_parent(idx)
+            .into_iter()
+            .chain(self.z_orientation_parent(idx))
+            .chain(self.z_scale_parent(idx))
+    }
+
+    //-----------------
+    // CHILDREN METHODS
+    //-----------------
+
+    /// A **Walker** type that may be used to step through the children of the given parent node.
+    pub fn children(&self, parent: node::Index) -> Children<S> {
+        let children = self.dag.children(parent);
+        Children { children }
+    }
+
+    // TODO: Add `x_position_children`, `position_children`, etc methods.
+}
+
+impl<S> Default for Graph<S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        let mut dag = Dag::new();
+        let origin = dag.add_node(Node::Point);
+        let vertices = Default::default();
+        Graph { dag, vertices, origin }
+    }
+}
+
+impl<S> GraphBase for Graph<S>
+where
+    S: BaseFloat,
+{
+    type NodeId = node::Index;
+    type EdgeId = edge::Index;
+}
+
+impl<S> Visitable for Graph<S>
+where
+    S: BaseFloat,
+{
+    type Map = <Dag<S> as Visitable>::Map;
+    fn visit_map(&self) -> Self::Map {
+        self.dag.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.dag.reset_map(map)
+    }
+}
+
+impl<'a, S> IntoNeighbors for &'a Graph<S>
+where
+    S: BaseFloat,
+{
+    type Neighbors = <&'a Dag<S> as IntoNeighbors>::Neighbors;
+    fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
+        self.dag.neighbors(n)
+    }
+}
+
+impl<S> ops::Index<node::Index> for Graph<S>
+where
+    S: BaseFloat,
+{
+    type Output = Node<S>;
+    fn index<'a>(&'a self, id: node::Index) -> &'a Self::Output {
+        self.node(id).unwrap()
+    }
+}
+
+impl<S> ops::Index<edge::Index> for Graph<S>
+where
+    S: BaseFloat,
+{
+    type Output = Edge<S>;
+    fn index<'a>(&'a self, idx: edge::Index) -> &'a Self::Output {
+        self.edge(idx).unwrap()
+    }
+}
+
+impl<'a, S> Walker<&'a Graph<S>> for Children<S>
+where
+    S: BaseFloat,
+{
+    type Item = (edge::Index, node::Index);
+    #[inline]
+    fn walk_next(&mut self, graph: &'a Graph<S>) -> Option<Self::Item> {
+        self.children.walk_next(&graph.dag)
+    }
+}
+
+impl<'a, S> Walker<&'a Graph<S>> for Parents<S>
+where
+    S: BaseFloat,
+{
+    type Item = (edge::Index, node::Index);
+    #[inline]
+    fn walk_next(&mut self, graph: &'a Graph<S>) -> Option<Self::Item> {
+        self.parents.walk_next(&graph.dag)
+    }
+}

--- a/src/geom/graph/node.rs
+++ b/src/geom/graph/node.rs
@@ -1,0 +1,723 @@
+//! Items related to the nodes of a geometry graph.
+
+use daggy::{self, Walker};
+use daggy::petgraph::visit::{self, Visitable};
+use geom;
+use geom::{DefaultScalar, Graph};
+use geom::graph::Edge;
+use math::{self, BaseFloat, Basis3, Euler, Point2, Point3, Rad, Rotation, Vector3, Zero};
+use std::collections::HashMap;
+use std::{iter, ops, slice};
+
+/// Unique index for a **Node** within a **Graph**.
+pub type Index = daggy::NodeIndex<usize>;
+
+/// Each of the primitive graphics types that may be instantiated within the graph.
+///
+/// Primitives that are described by a dynamic number of vertices share a single vertex buffer
+/// that is owned by the graph. These variants store a range into this vertex buffer indicating
+/// which slice of vertices describe it.
+#[derive(Clone, Debug)]
+pub enum Primitive<S = DefaultScalar> {
+    Cuboid(geom::Cuboid<S>),
+    Ellipse(geom::Ellipse<S>),
+    Line(geom::Line<S>),
+    Polygon {
+        range: ops::Range<usize>,
+    },
+    Polyline {
+        join: geom::polyline::join::Dynamic,
+        cap: geom::polyline::cap::Dynamic,
+        range: ops::Range<usize>,
+        thickness: S,
+    },
+    Quad(geom::Quad<Point3<S>>),
+    Rect(geom::Rect<S>),
+    Tri(geom::Tri<Point3<S>>),
+}
+
+/// An iterator yielding all vertices for a primitive.
+#[derive(Clone)]
+pub enum PrimitiveVertices<'a, S: 'a = DefaultScalar> {
+    Cuboid(geom::cuboid::Corners<'a, S>),
+    Ellipse(geom::ellipse::Circumference<S>),
+    Line(geom::line::Vertices<S>),
+    Polygon(iter::Cloned<slice::Iter<'a, Point3<S>>>),
+    // TODO: Add a `polyline::Part::vertices` method and use `polyline::Vertices` instead.
+    //Polyline(geom::polyline::DynamicTriangles<slice::Iter<'a, Point3<S>>, S>),
+    Quad(geom::quad::Vertices<Point3<S>>),
+    Rect(geom::rect::Corners<S>),
+    Tri(geom::tri::Vertices<Point3<S>>),
+}
+
+/// An iterator yielding all triangles for a primitive.
+#[derive(Clone)]
+pub enum PrimitiveTriangles<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    Cuboid(geom::cuboid::Triangles<'a, S>),
+    Ellipse(geom::ellipse::Triangles<S>),
+    Line(geom::line::Triangles<S>),
+    Polygon(Option<geom::polygon::Triangles<iter::Cloned<slice::Iter<'a, Point3<S>>>>>),
+    Polyline(geom::polyline::DynamicTriangles<iter::Cloned<slice::Iter<'a, Point3<S>>>>),
+    Quad(geom::quad::Triangles<Point3<S>>),
+    Rect(geom::rect::Triangles<S>),
+    Tri(Option<geom::Tri<Point3<S>>>),
+}
+
+/// The **Node** type used within the **Graph**.
+#[derive(Clone, Debug)]
+pub enum Node<S = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    /// A point has no vertices other than that yielded at the node's position.
+    ///
+    /// Useful for acting as an invisible "reference" node for controlling other children nodes.
+    ///
+    /// Also used to represent the graph's "origin" node.
+    Point,
+    /// A node representing some primitive geometric type (e.g. `Tri`, `Cuboid`, `Quad`, etc).
+    Primitive(Primitive<S>),
+    /// A nested Graph.
+    Graph {
+        graph: super::Graph<S>,
+        dfs: Dfs<S>,
+    },
+}
+
+/// An iterator yielding all vertices from a node.
+pub enum Vertices<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    Point(Option<Point3<S>>),
+    Primitive(PrimitiveVertices<'a, S>),
+    Graph(geom::graph::Vertices<'a, S>),
+}
+
+/// An iterator yielding all triangles from a node.
+pub enum Triangles<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    Point,
+    Primitive(PrimitiveTriangles<'a, S>),
+    Graph(geom::graph::Triangles<'a, S>),
+}
+
+/// An iterator yielding all vertices for a node transformed by some given transform.
+pub struct TransformedVertices<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    transform: Transform<S>,
+    vertices: Vertices<'a, S>,
+}
+
+/// An iterator yielding all vertices for a node transformed by some given transform.
+pub struct TransformedTriangles<'a, S: 'a = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    transform: Transform<S>,
+    triangles: Triangles<'a, S>,
+}
+
+/// A node's resulting rotation, displacement and scale relative to the graph's origin.
+///
+/// A transform is calculated and applied to a node's vertices in the following order:
+///
+/// 1. **scale**: `1.0 * parent_scale * edge_scale`
+/// 2. **rotation**: `0.0 + parent_position + edge_displacement`
+/// 3. **displacement**: 0.0 + parent_orientation + edge_orientation`
+#[derive(Clone, Debug, PartialEq)]
+pub struct Transform<S = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    /// A scaling amount along each axis.
+    ///
+    /// The scaling amount is multiplied onto each vertex of the node.
+    pub scale: Vector3<S>,
+    /// A rotation amount along each axis, describing a relative orientation.
+    ///
+    /// Rotates all vertices around the node origin when applied.
+    pub rot: Euler<Rad<S>>,
+    /// A displacement amount along each axis.
+    ///
+    /// This vector is added onto the position of each vertex of the node.
+    pub disp: Vector3<S>,
+}
+
+/// A depth-first-search over nodes in the graph, yielding each node's unique index alongside its
+/// absolute transform.
+///
+/// The traversal may start at any given node.
+///
+/// **Note:** The algorithm may not behave correctly if nodes are removed during iteration. It may
+/// not necessarily visit added nodes or edges.
+#[derive(Clone, Debug)]
+pub struct Dfs<S = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    dfs: visit::Dfs<Index, <Graph<S> as Visitable>::Map>,
+    visited: TransformMap<S>,
+}
+
+impl<S> Dfs<S>
+where
+    S: BaseFloat,
+{
+    /// Create a new **Dfs** starting from the graph's origin.
+    pub fn new(graph: &Graph<S>) -> Self {
+        Self::start_from(graph, graph.origin())
+    }
+
+    /// Create a new **Dfs** starting from the node at the given node.
+    pub fn start_from(graph: &Graph<S>, start: Index) -> Self {
+        let dfs = visit::Dfs::new(graph, start);
+        let visited = TransformMap::default();
+        Dfs { dfs, visited }
+    }
+
+    /// Clears the visit state.
+    pub fn reset(&mut self, graph: &Graph<S>) {
+        self.dfs.reset(graph);
+    }
+
+    /// Keep the discovered map but clear the visit stack and restart the dfs from the given node.
+    pub fn move_to(&mut self, start: Index) {
+        self.dfs.move_to(start);
+    }
+
+    /// Return the tranform for the next node in the DFS.
+    ///
+    /// Returns `None` if the traversal is finished.
+    pub fn next_transform(&mut self, graph: &Graph<S>) -> Option<(Index, Transform<S>)> {
+        let n = match self.dfs.next(graph) {
+            None => return None,
+            Some(n) => n,
+        };
+        let mut transform = Transform::default();
+        for (e, parent) in graph.parents(n).iter(graph) {
+            let parent_transform = &self.visited[&parent];
+            let edge = &graph[e];
+            transform.apply_edge(parent_transform, edge);
+        }
+        self.visited.map.insert(n, transform.clone());
+        Some((n, transform))
+    }
+
+    /// Return the vertices for the next node in the DFS.
+    ///
+    /// Uses `Dfs::next_transform` and `Node::vertices` internally.
+    ///
+    /// Returns `None` if the traversal is finished.
+    pub fn next_vertices<'a>(
+        &mut self,
+        graph: &'a Graph<S>,
+    ) -> Option<(Index, TransformedVertices<'a, S>)>
+    {
+        self.next_transform(graph)
+            .and_then(|(n, transform)| {
+                graph.node(n)
+                    .map(|node| {
+                        let vertices = node.vertices(&graph.vertices);
+                        (n, TransformedVertices { vertices, transform })
+                    })
+            })
+    }
+
+    /// Return the triangles for the next node in the DFS.
+    ///
+    /// Uses `Dfs::next_transform` and `Node::triangles` internally.
+    ///
+    /// Returns `None` if the traversal is finished.
+    pub fn next_triangles<'a>(
+        &mut self,
+        graph: &'a Graph<S>,
+    ) -> Option<(Index, TransformedTriangles<'a, S>)>
+    {
+        self.next_transform(graph)
+            .and_then(|(n, transform)| {
+                graph.node(n)
+                    .map(|node| {
+                        let triangles = node.triangles(&graph.vertices);
+                        (n, TransformedTriangles { triangles, transform })
+                    })
+            })
+    }
+}
+
+impl<'a, S> Walker<&'a Graph<S>> for Dfs<S>
+where
+    S: BaseFloat,
+{
+    type Item = (Index, Transform<S>);
+    fn walk_next(&mut self, graph: &'a Graph<S>) -> Option<Self::Item> {
+        self.next_transform(graph)
+    }
+}
+
+/// Mappings from node indices to their respective transform within the graph.
+///
+/// This is calculated via the `Graph::update_transform_map` method.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransformMap<S = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    map: HashMap<Index, Transform<S>>
+}
+
+impl<S> Default for TransformMap<S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        TransformMap {
+            map: Default::default(),
+        }
+    }
+}
+
+impl<S> ops::Deref for TransformMap<S>
+where
+    S: BaseFloat,
+{
+    type Target = HashMap<Index, Transform<S>>;
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<S> Into<HashMap<Index, Transform<S>>> for TransformMap<S>
+where
+    S: BaseFloat,
+{
+    fn into(self) -> HashMap<Index, Transform<S>> {
+        self.map
+    }
+}
+
+impl<S> Transform<S>
+where
+    S: BaseFloat,
+{
+    /// Apply the given parent `Edge` to this transform.
+    pub fn apply_edge(&mut self, parent: &Self, edge: &Edge<S>) {
+        use geom::graph::edge::{Axis, Relative};
+        match (edge.kind.relative, edge.kind.axis) {
+            (Relative::Position, Axis::X) => self.disp.x += parent.disp.x + edge.weight,
+            (Relative::Position, Axis::Y) => self.disp.y += parent.disp.y + edge.weight,
+            (Relative::Position, Axis::Z) => self.disp.z += parent.disp.z + edge.weight,
+            (Relative::Orientation, Axis::X) => self.rot.x += parent.rot.x + Rad(edge.weight),
+            (Relative::Orientation, Axis::Y) => self.rot.y += parent.rot.y + Rad(edge.weight),
+            (Relative::Orientation, Axis::Z) => self.rot.z += parent.rot.z + Rad(edge.weight),
+            (Relative::Scale, Axis::X) => self.scale.x *= parent.scale.x * edge.weight,
+            (Relative::Scale, Axis::Y) => self.scale.y *= parent.scale.y * edge.weight,
+            (Relative::Scale, Axis::Z) => self.scale.z *= parent.scale.z * edge.weight,
+        }
+    }
+}
+
+impl<S> Default for Transform<S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        let zero = S::zero();
+        let one = S::one();
+        let scale = Vector3 { x: one, y: one, z: one };
+        let rot = Euler { x: Rad(zero), y: Rad(zero), z: Rad(zero) };
+        let disp = Vector3 { x: zero, y: zero, z: zero };
+        Transform { scale, rot, disp }
+    }
+}
+
+impl<S> math::Transform<Point3<S>> for Transform<S>
+where
+    S: BaseFloat,
+{
+    fn one() -> Self {
+        let one = S::one();
+        let (x, y, z) = (one, one, one);
+        Transform {
+            scale: Vector3 { x, y, z },
+            rot: Euler { x: Rad(x), y: Rad(y), z: Rad(z) },
+            disp: Vector3 { x, y, z },
+        }
+    }
+
+    fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Self {
+        unimplemented!();
+    }
+
+    fn transform_vector(&self, vec: Vector3<S>) -> Vector3<S> {
+        unimplemented!();
+    }
+
+    fn inverse_transform_vector(&self, vec: Vector3<S>) -> Option<Vector3<S>> {
+        unimplemented!();
+    }
+
+    fn transform_point(&self, point: Point3<S>) -> Point3<S> {
+        unimplemented!();
+    }
+
+    fn concat(&self, other: &Self) -> Self {
+        unimplemented!();
+    }
+
+    fn inverse_transform(&self) -> Option<Self> {
+        unimplemented!();
+    }
+}
+
+fn transform_point<S>(transform: &Transform<S>, mut point: Point3<S>) -> Point3<S>
+where
+    S: BaseFloat,
+{
+    // Scale the point relative to the node origin.
+    point.x *= transform.scale.x;
+    point.y *= transform.scale.y;
+    point.z *= transform.scale.z;
+    // Rotate the point around the node origin.
+    point = Basis3::from(transform.rot).rotate_point(point);
+    // Displace the point from the node origin.
+    point += transform.disp;
+    point
+}
+
+impl<'a, S> Iterator for TransformedVertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = Point3<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.vertices
+            .next()
+            .map(|point| transform_point(&self.transform, point))
+    }
+}
+
+impl<'a, S> Iterator for TransformedTriangles<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = geom::Tri<Point3<S>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.triangles
+            .next()
+            .map(|tri| tri.map(|point| transform_point(&self.transform, point)))
+    }
+}
+
+impl<S> Primitive<S>
+where
+    S: BaseFloat,
+{
+    /// The `Cuboid` that bounds the primitive.
+    ///
+    /// Returns `None` if the primitive is a polygon or polyline with no points.
+    pub fn bounding_cuboid(&self, vertices: &[Point3<S>]) -> Option<geom::Cuboid<S>> {
+        match *self {
+            Primitive::Cuboid(ref cuboid) => {
+                geom::bounding_cuboid(cuboid.corners_iter())
+            },
+            Primitive::Ellipse(ref ellipse) => {
+                let (x, y) = (ellipse.rect.x, ellipse.rect.y);
+                let z = geom::Range::new(Zero::zero(), Zero::zero());
+                Some(geom::Cuboid { x, y, z })
+            },
+            Primitive::Line(ref line) => {
+                let q = line.quad_corners();
+                let vertices = q.iter()
+                    .map(|p| {
+                        let x = p.x;
+                        let y = p.y;
+                        let z = Zero::zero();
+                        Point3 { x, y, z }
+                    });
+                geom::bounding_cuboid(vertices)
+            },
+            Primitive::Polygon { ref range } => {
+                let vertices = vertices[range.clone()].iter().cloned();
+                geom::bounding_cuboid(vertices)
+            },
+            Primitive::Polyline { join, cap, ref range, thickness } => {
+                let vertices = vertices[range.clone()]
+                    .iter()
+                    .cloned()
+                    .map(|p| Point2 { x: p.x, y: p.y });
+                geom::Polyline::new(cap, join, vertices, thickness)
+                    .bounding_rect()
+                    .map(|rect| {
+                        let (x, y) = (rect.x, rect.y);
+                        let z = geom::Range::new(Zero::zero(), Zero::zero());
+                        geom::Cuboid { x, y, z }
+                    })
+            },
+            Primitive::Quad(ref quad) => {
+                let vertices = quad.iter().cloned();
+                geom::bounding_cuboid(vertices)
+            },
+            Primitive::Rect(ref rect) => {
+                let (x, y) = (rect.x, rect.y);
+                let z = geom::Range::new(Zero::zero(), Zero::zero());
+                Some(geom::Cuboid { x, y, z })
+            },
+            Primitive::Tri(ref tri) => {
+                let r = tri.bounding_rect();
+                let (x, y) = (r.x, r.y);
+                let z = geom::Range::new(Zero::zero(), Zero::zero());
+                Some(geom::Cuboid { x, y, z })
+            },
+        }
+    }
+
+    /// Produce an iterator yielding all vertices within the primitive.
+    pub fn vertices<'a>(&'a self, vertices: &'a [Point3<S>]) -> PrimitiveVertices<'a, S> {
+        match *self {
+            Primitive::Cuboid(ref cuboid) => {
+                PrimitiveVertices::Cuboid(cuboid.corners_iter())
+            },
+            Primitive::Ellipse(ref ellipse) => {
+                PrimitiveVertices::Ellipse(ellipse.circumference())
+            },
+            Primitive::Line(ref line) => {
+                PrimitiveVertices::Line(line.quad_corners_iter())
+            },
+            Primitive::Polygon { ref range } => {
+                let slice = &vertices[range.clone()];
+                PrimitiveVertices::Polygon(slice.iter().cloned())
+            },
+            Primitive::Polyline { .. } => {
+                unimplemented!();
+            },
+            Primitive::Quad(ref quad) => {
+                PrimitiveVertices::Quad(quad.vertices())
+            },
+            Primitive::Rect(ref rect) => {
+                PrimitiveVertices::Rect(rect.corners_iter())
+            },
+            Primitive::Tri(ref tri) => {
+                PrimitiveVertices::Tri(tri.vertices())
+            },
+        }
+    }
+
+    /// Produce an iterator yielding all triangles within the primitive.
+    pub fn triangles<'a>(&'a self, vertices: &'a [Point3<S>]) -> PrimitiveTriangles<'a, S> {
+        match *self {
+            Primitive::Cuboid(ref cuboid) => {
+                PrimitiveTriangles::Cuboid(cuboid.triangles_iter())
+            },
+            Primitive::Ellipse(ref ellipse) => {
+                PrimitiveTriangles::Ellipse(ellipse.triangles())
+            },
+            Primitive::Line(ref line) => {
+                PrimitiveTriangles::Line(line.triangles_iter())
+            },
+            Primitive::Polygon { ref range } => {
+                let slice = &vertices[range.clone()];
+                let polygon = geom::Polygon::new(slice.iter().cloned());
+                PrimitiveTriangles::Polygon(polygon.triangles())
+            },
+            Primitive::Polyline { .. } => {
+                unimplemented!();
+            },
+            Primitive::Quad(ref quad) => {
+                PrimitiveTriangles::Quad(quad.triangles_iter())
+            },
+            Primitive::Rect(ref rect) => {
+                PrimitiveTriangles::Rect(rect.triangles_iter())
+            },
+            Primitive::Tri(ref tri) => {
+                PrimitiveTriangles::Tri(Some(*tri))
+            },
+        }
+    }
+}
+
+// A small function used for mapping 2D points to 3D ones within the PrimitiveVertices and
+// PrimitiveTriangles iterators.
+fn pt2_to_pt3<S>(p: Point2<S>) -> Point3<S>
+where
+    S: BaseFloat,
+{
+    let x = p.x;
+    let y = p.y;
+    let z = Zero::zero();
+    Point3 { x, y, z }
+}
+
+impl<'a, S> Iterator for PrimitiveVertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = Point3<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match *self {
+            PrimitiveVertices::Cuboid(ref mut corners) => {
+                corners.next()
+            },
+            PrimitiveVertices::Ellipse(ref mut circumference) => {
+                circumference.next().map(pt2_to_pt3)
+            },
+            PrimitiveVertices::Line(ref mut vertices) => {
+                vertices.next().map(pt2_to_pt3)
+            },
+            PrimitiveVertices::Polygon(ref mut vertices) => {
+                vertices.next()
+            },
+            // PrimitiveVertices::Polyline(ref mut vertices) => {
+            //     vertices.next()
+            // },
+            PrimitiveVertices::Quad(ref mut vertices) => {
+                vertices.next()
+            },
+            PrimitiveVertices::Rect(ref mut corners) => {
+                corners.next().map(pt2_to_pt3)
+            },
+            PrimitiveVertices::Tri(ref mut vertices) => {
+                vertices.next()
+            },
+        }
+    }
+}
+
+impl<'a, S> Iterator for PrimitiveTriangles<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = geom::Tri<Point3<S>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match *self {
+            PrimitiveTriangles::Cuboid(ref mut tris) => {
+                tris.next()
+            },
+            PrimitiveTriangles::Ellipse(ref mut tris) => {
+                tris.next().map(|t| t.map(pt2_to_pt3))
+            },
+            PrimitiveTriangles::Line(ref mut tris) => {
+                tris.next().map(|t| t.map(pt2_to_pt3))
+            },
+            PrimitiveTriangles::Polygon(ref mut tris) => {
+                tris.as_mut().and_then(|ts| ts.next())
+            },
+            PrimitiveTriangles::Polyline(ref mut _tris) => {
+                unimplemented!();
+                // TODO: Implement Iterator for DynamicTriangles
+                //tris.next().map(|t| t.map(pt2_to_pt3))
+            },
+            PrimitiveTriangles::Quad(ref mut tris) => {
+                tris.next()
+            },
+            PrimitiveTriangles::Rect(ref mut tris) => {
+                tris.next().map(|t| t.map(pt2_to_pt3))
+            },
+            PrimitiveTriangles::Tri(ref mut tri) => {
+                tri.take()
+            },
+        }
+    }
+}
+
+impl<'a, S> Iterator for Vertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = Point3<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match *self {
+            // A node point is always at the node's origin.
+            Vertices::Point(ref mut point) => {
+                point.take()
+            },
+            Vertices::Primitive(ref mut vertices) => {
+                vertices.next()
+            },
+            Vertices::Graph(ref mut vertices) => {
+                vertices.next()
+            },
+        }
+    }
+}
+
+impl<'a, S> Iterator for Triangles<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = geom::Tri<Point3<S>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match *self {
+            Triangles::Point => {
+                None
+            },
+            Triangles::Primitive(ref mut triangles) => {
+                triangles.next()
+            },
+            Triangles::Graph(ref mut triangles) => {
+                triangles.next()
+            },
+        }
+    }
+}
+
+impl<S> Node<S>
+where
+    S: BaseFloat,
+{
+    /// The `Cuboid` that bounds the primitive.
+    ///
+    /// Returns `None` if the primitive is a polygon, polyline or graph with no points.
+    pub fn bounding_cuboid(&self, vertices: &[Point3<S>]) -> Option<geom::Cuboid<S>> {
+        match *self {
+            Node::Point => {
+                let zero = Zero::zero();
+                let x = geom::Range::new(zero, zero);
+                let y = geom::Range::new(zero, zero);
+                let z = geom::Range::new(zero, zero);
+                Some(geom::Cuboid { x, y, z })
+            },
+            Node::Primitive(ref primitive) => primitive.bounding_cuboid(vertices),
+            Node::Graph { ref graph, .. } => graph.bounding_cuboid(),
+        }
+    }
+
+    /// Produce an iterator yielding all vertices within the node.
+    pub fn vertices<'a>(&'a self, vertices: &'a [Point3<S>]) -> Vertices<'a, S> {
+        match *self {
+            Node::Point => {
+                let zero = Zero::zero();
+                let (x, y, z) = (zero, zero, zero);
+                Vertices::Point(Some(Point3 { x, y, z }))
+            },
+            Node::Primitive(ref primitive) => {
+                Vertices::Primitive(primitive.vertices(vertices))
+            },
+            Node::Graph { .. } => {
+                unimplemented!();
+            },
+        }
+    }
+
+    /// Produce an iterator yielding all triangles within the node.
+    pub fn triangles<'a>(&'a self, vertices: &'a [Point3<S>]) -> Triangles<'a, S> {
+        match *self {
+            Node::Point => {
+                Triangles::Point
+            },
+            Node::Primitive(ref primitive) => {
+                Triangles::Primitive(primitive.triangles(vertices))
+            },
+            Node::Graph { .. } => {
+                unimplemented!();
+            }
+        }
+    }
+}

--- a/src/geom/line.rs
+++ b/src/geom/line.rs
@@ -5,6 +5,51 @@ use math::{two, vec2, BaseFloat, Point2};
 /// The iterator type yielding triangles that describe a line.
 pub type Triangles<S> = quad::Triangles<Point2<S>>;
 
+/// A line represented by two points.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Line<S> {
+    /// The start point of the line.
+    pub start: Point2<S>,
+    /// The end point of the line.
+    pub end: Point2<S>,
+    /// Half of the thickness of the line.
+    pub half_thickness: S,
+}
+
+impl<S> Line<S>
+where
+    S: BaseFloat,
+{
+    /// Short-hand constructor for a `Line`.
+    pub fn new(start: Point2<S>, end: Point2<S>, half_thickness: S) -> Self {
+        Line { start, end, half_thickness }
+    }
+
+    /// The four corners of the rectangle describing the line.
+    pub fn quad_corners(&self) -> [Point2<S>; 4] {
+        quad_corners(self.start, self.end, self.half_thickness)
+    }
+
+    /// The two triangles that describe the line.
+    pub fn triangles(&self) -> [Tri<Point2<S>>; 2] {
+        triangles(self.start, self.end, self.half_thickness)
+    }
+
+    /// Given two points and half the line thickness, return the two triangles that describe the line.
+    pub fn triangles_iter(&self) -> Triangles<S> {
+        triangles_iter(self.start, self.end, self.half_thickness)
+    }
+
+    /// Describes whether or not the given point touches the line.
+    ///
+    /// If so, the `Tri` containing the point will be returned.
+    ///
+    /// `None` is returned otherwise.
+    pub fn contains(&self, point: &Point2<S>) -> Option<Tri<Point2<S>>> {
+        contains(self.start, self.end, self.half_thickness, point)
+    }
+}
+
 /// Given two points and half the line thickness, return the four corners of the rectangle
 /// describing the line.
 ///

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -1,5 +1,8 @@
+use math::{Point2, Point3};
+
 pub mod cuboid;
 pub mod ellipse;
+pub mod graph;
 pub mod line;
 pub mod polyline;
 pub mod polygon;
@@ -7,10 +10,67 @@ pub mod quad;
 pub mod range;
 pub mod rect;
 pub mod tri;
+pub mod vertex;
 
 pub use self::cuboid::Cuboid;
+pub use self::ellipse::Ellipse;
+pub use self::graph::Graph;
 pub use self::line::Line;
+pub use self::polygon::Polygon;
+pub use self::polyline::Polyline;
 pub use self::quad::Quad;
 pub use self::range::{Align, Edge, Range};
 pub use self::rect::{Corner, Padding, Rect};
 pub use self::tri::Tri;
+pub use self::vertex::{DefaultScalar, Vertex, Vertex2d, Vertex3d};
+
+// General geometry utility functions
+
+/// The `Rect` that bounds the given sequence of vertices.
+///
+/// Returns `None` if the given iterator is empty.
+pub fn bounding_rect<I>(vertices: I) -> Option<Rect<<I::Item as Vertex>::Scalar>>
+where
+    I: IntoIterator,
+    I::Item: Vertex2d,
+{
+    let mut vertices = vertices.into_iter();
+    vertices.next()
+        .map(|first| {
+            let Point2 { x, y } = first.point2();
+            let bounds = Rect {
+                x: Range::new(x, x),
+                y: Range::new(y, y),
+            };
+            vertices.fold(bounds, |b, v| {
+                let Point2 { x, y } = v.point2();
+                let point = Point2 { x, y };
+                b.stretch_to_point(point)
+            })
+        })
+}
+
+/// The `Cuboid` that bounds the given sequence of vertices.
+///
+/// Returns `None` if the given iterator is empty.
+pub fn bounding_cuboid<I>(vertices: I) -> Option<Cuboid<<I::Item as Vertex>::Scalar>>
+where
+    I: IntoIterator,
+    I::Item: Vertex3d,
+{
+    let mut vertices = vertices.into_iter();
+    vertices.next()
+        .map(|first| {
+            let Point3 { x, y, z } = first.point3();
+            let bounds = Cuboid {
+                x: Range::new(x, x),
+                y: Range::new(y, y),
+                z: Range::new(z, z),
+            };
+            vertices.fold(bounds, |b, v| {
+                let Point3 { x, y, z } = v.point3();
+                let point = Point3 { x, y, z };
+                b.stretch_to_point(point)
+            })
+        })
+}

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -9,6 +9,7 @@ pub mod rect;
 pub mod tri;
 
 pub use self::cuboid::Cuboid;
+pub use self::line::Line;
 pub use self::quad::Quad;
 pub use self::range::{Align, Edge, Range};
 pub use self::rect::{Corner, Padding, Rect};

--- a/src/geom/quad.rs
+++ b/src/geom/quad.rs
@@ -1,13 +1,116 @@
-use geom::Tri;
+use geom::{vertex, Tri, Vertex};
+use math::EuclideanSpace;
+use std::ops::{Deref, Index};
 
-/// A quad represented by its corners.
-pub type Quad<V> = [V; 4];
+/// The number of vertices in a quad.
+pub const NUM_VERTICES: u8 = 4;
+
+/// A quad represented by its four vertices.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Quad<V = vertex::Default>(pub [V; NUM_VERTICES as usize]);
 
 /// An `Iterator` yielding the two triangles that make up a quad.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Triangles<V> {
     a: Option<Tri<V>>,
     b: Option<Tri<V>>,
+}
+
+/// A simple iterator yielding each vertex in a `Quad`.
+#[derive(Clone, Debug)]
+pub struct Vertices<V> {
+    quad: Quad<V>,
+    index: u8,
+}
+
+impl<V> Quad<V>
+where
+    V: Vertex,
+{
+    /// Produce an iterator yielding each vertex in the `Quad`.
+    pub fn vertices(self) -> Vertices<V> {
+        vertices(self)
+    }
+
+    /// Produce the centroid of the quad, aka the "mean"/"average" vertex.
+    pub fn centroid(&self) -> V
+    where
+        V: EuclideanSpace,
+    {
+        centroid(self)
+    }
+
+    /// Triangulates the given quad, represented by four points that describe its edges in either
+    /// clockwise or anti-clockwise order.
+    ///
+    /// # Example
+    ///
+    /// The following rectangle
+    ///
+    /// ```ignore
+    ///  a        b
+    ///   --------
+    ///   |      |
+    ///   |      |
+    ///   |      |
+    ///   --------
+    ///  d        c
+    ///
+    /// ```
+    ///
+    /// given as
+    ///
+    /// ```ignore
+    /// triangles([a, b, c, d])
+    /// ```
+    ///
+    /// returns
+    ///
+    /// ```ignore
+    /// (Tri([a, b, c]), Tri([a, c, d]))
+    /// ```
+    ///
+    /// Here's a basic code example:
+    ///
+    /// ```
+    /// extern crate nannou;
+    ///
+    /// use nannou::geom::{self, Quad, Tri};
+    /// use nannou::math::pt2;
+    ///
+    /// fn main() {
+    ///     let a = pt2(0.0, 1.0);
+    ///     let b = pt2(1.0, 1.0);
+    ///     let c = pt2(1.0, 0.0);
+    ///     let d = pt2(0.0, 0.0);
+    ///     let quad = Quad([a, b, c, d]);
+    ///     let triangles = geom::quad::triangles(&quad);
+    ///     assert_eq!(triangles, (Tri([a, b, c]), Tri([a, c, d])));
+    /// }
+    /// ```
+    #[inline]
+    pub fn triangles(&self) -> (Tri<V>, Tri<V>) {
+        triangles(self)
+    }
+
+    /// The same as `triangles` but provided as an `Iterator`.
+    pub fn triangles_iter(&self) -> Triangles<V> {
+        triangles_iter(self)
+    }
+}
+
+/// Produce an iterator yielding each vertex in the given `Quad`.
+pub fn vertices<V>(quad: Quad<V>) -> Vertices<V> {
+    let index = 0;
+    Vertices { quad, index }
+}
+
+/// Produce the centroid of the quad, aka the "mean"/"average" vertex.
+pub fn centroid<V>(quad: &Quad<V>) -> V
+where
+    V: EuclideanSpace,
+{
+    EuclideanSpace::centroid(&quad[..])
 }
 
 /// Triangulates the given quad, represented by four points that describe its edges in either
@@ -46,32 +149,32 @@ pub struct Triangles<V> {
 /// ```
 /// extern crate nannou;
 ///
-/// use nannou::geom::{self, Tri};
-/// use nannou::math::vec2;
+/// use nannou::geom::{self, Quad, Tri};
+/// use nannou::math::pt2;
 ///
 /// fn main() {
-///     let a = vec2(0.0, 1.0);
-///     let b = vec2(1.0, 1.0);
-///     let c = vec2(1.0, 0.0);
-///     let d = vec2(0.0, 0.0);
-///     let quad = [a, b, c, d];
+///     let a = pt2(0.0, 1.0);
+///     let b = pt2(1.0, 1.0);
+///     let c = pt2(1.0, 0.0);
+///     let d = pt2(0.0, 0.0);
+///     let quad = Quad([a, b, c, d]);
 ///     let triangles = geom::quad::triangles(&quad);
 ///     assert_eq!(triangles, (Tri([a, b, c]), Tri([a, c, d])));
 /// }
 /// ```
 #[inline]
-pub fn triangles<V>(points: &[V; 4]) -> (Tri<V>, Tri<V>)
+pub fn triangles<V>(points: &Quad<V>) -> (Tri<V>, Tri<V>)
 where
-    V: Copy,
+    V: Vertex,
 {
     let (a, b, c, d) = (points[0], points[1], points[2], points[3]);
     (Tri([a, b, c]), Tri([a, c, d]))
 }
 
 /// The same as `triangles` but provided as an `Iterator`.
-pub fn triangles_iter<V>(points: &[V; 4]) -> Triangles<V>
+pub fn triangles_iter<V>(points: &Quad<V>) -> Triangles<V>
 where
-    V: Copy,
+    V: Vertex,
 {
     let (a, b) = triangles(points);
     Triangles {
@@ -104,5 +207,92 @@ impl<V> ExactSizeIterator for Triangles<V> {
             (&None, &Some(_)) => 0,
             _ => 1,
         }
+    }
+}
+
+impl<V> Iterator for Vertices<V>
+where
+    V: Clone,
+{
+    type Item = V;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < NUM_VERTICES {
+            let v = self.quad[self.index as usize].clone();
+            self.index += 1;
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+impl<V> Deref for Quad<V> {
+    type Target = [V; NUM_VERTICES as usize];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> From<[V; NUM_VERTICES as usize]> for Quad<V>
+where
+    V: Vertex,
+{
+    fn from(points: [V; NUM_VERTICES as usize]) -> Self {
+        Quad(points)
+    }
+}
+
+impl<V> From<(V, V, V, V)> for Quad<V>
+where
+    V: Vertex,
+{
+    fn from((a, b, c, d): (V, V, V, V)) -> Self {
+        Quad([a, b, c, d])
+    }
+}
+
+impl<V> Into<[V; NUM_VERTICES as usize]> for Quad<V>
+where
+    V: Vertex,
+{
+    fn into(self) -> [V; NUM_VERTICES as usize] {
+        self.0
+    }
+}
+
+impl<V> Into<(V, V, V, V)> for Quad<V>
+where
+    V: Vertex,
+{
+    fn into(self) -> (V, V, V, V) {
+        (self[0], self[1], self[2], self[3])
+    }
+}
+
+impl<V> AsRef<Quad<V>> for Quad<V>
+where
+    V: Vertex,
+{
+    fn as_ref(&self) -> &Quad<V> {
+        self
+    }
+}
+
+impl<V> AsRef<[V; NUM_VERTICES as usize]> for Quad<V>
+where
+    V: Vertex,
+{
+    fn as_ref(&self) -> &[V; NUM_VERTICES as usize] {
+        &self.0
+    }
+}
+
+impl<V> Index<usize> for Quad<V>
+where
+    V: Vertex,
+{
+    type Output = V;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
     }
 }

--- a/src/geom/vertex.rs
+++ b/src/geom/vertex.rs
@@ -1,0 +1,182 @@
+use color;
+use math::{BaseNum, Point2, Point3};
+use std::ops::{Deref, DerefMut};
+
+/// Types used as vertices that can be used to describe geometric points in space.
+pub trait Vertex: Clone + Copy + PartialEq {
+    /// The values used to describe the vertex position.
+    type Scalar: BaseNum;
+}
+
+/// Vertex types that have at least 2 dimensions.
+pub trait Vertex2d: Vertex {
+    /// The x, y location of the vertex.
+    fn point2(self) -> Point2<Self::Scalar>;
+}
+
+/// Vertex types that have at least 3 dimensions.
+pub trait Vertex3d: Vertex2d {
+    /// The x, y, z location of the vertex.
+    fn point3(self) -> Point3<Self::Scalar>;
+}
+
+/// If a type is not specified for a scalar along an axis, this is the default type used.
+pub type DefaultScalar = f64;
+/// If a type is not specified for a piece of geometry, this is the default type used.
+pub type Default = Point3<DefaultScalar>;
+
+/// A vertex that is colored with the given linear `RGBA` color.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Rgba<V = Default>(pub V, pub color::Rgba);
+
+// Rgba impls.
+
+impl<V> Rgba<V> {
+    /// A reference to the inner vertex.
+    pub fn vertex(&self) -> &V {
+        &self.0
+    }
+    /// A reference to the inner rgba.
+    pub fn rgba(&self) -> &color::Rgba {
+        &self.1
+    }
+}
+
+impl<V> Deref for Rgba<V> {
+    type Target = V;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<V> DerefMut for Rgba<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<V> From<(V, color::Rgba)> for Rgba<V> {
+    fn from((v, rgba): (V, color::Rgba)) -> Self {
+        Rgba(v, rgba)
+    }
+}
+
+impl<V> Into<(V, color::Rgba)> for Rgba<V> {
+    fn into(self) -> (V, color::Rgba) {
+        let Rgba(v, rgba) = self;
+        (v, rgba)
+    }
+}
+
+// Vertex impls
+
+impl<S> Vertex for Point2<S>
+where
+    S: BaseNum,
+{
+    type Scalar = S;
+}
+
+impl<S> Vertex for Point3<S>
+where
+    S: BaseNum,
+{
+    type Scalar = S;
+}
+
+// impl<S> Vertex for Vector2<S>
+// where
+//     S: BaseNum,
+// {
+//     type Scalar = S;
+// }
+// 
+// impl<S> Vertex for Vector3<S>
+// where
+//     S: BaseNum,
+// {
+//     type Scalar = S;
+// }
+
+impl<V> Vertex for Rgba<V>
+where
+    V: Vertex,
+{
+    type Scalar = V::Scalar;
+}
+
+// Vertex2d impls
+
+impl<S> Vertex2d for Point2<S>
+where
+    S: BaseNum,
+{
+    fn point2(self) -> Point2<S> {
+        Point2 { x: self.x, y: self.y }
+    }
+}
+
+impl<S> Vertex2d for Point3<S>
+where
+    S: BaseNum,
+{
+    fn point2(self) -> Point2<S> {
+        Point2 { x: self.x, y: self.y }
+    }
+}
+
+// impl<S> Vertex2d for Vector2<S>
+// where
+//     S: BaseNum,
+// {
+//     fn point2(self) -> Point2<S> {
+//         self
+//     }
+// }
+// 
+// impl<S> Vertex2d for Vector3<S>
+// where
+//     S: BaseNum,
+// {
+//     fn point2(self) -> Point2<S> {
+//         Point2 { x: self.x, y: self.y }
+//     }
+// }
+
+impl<V> Vertex2d for Rgba<V>
+where
+    V: Vertex2d,
+{
+    fn point2(self) -> Point2<V::Scalar> {
+        self.0.point2()
+    }
+}
+
+// Vertex3d impls
+
+impl<S> Vertex3d for Point3<S>
+where
+    S: BaseNum,
+{
+    fn point3(self) -> Point3<S> {
+        Point3 { x: self.x, y: self.y, z: self.z }
+    }
+}
+
+// impl<S> Vertex3d for Vector3<S>
+// where
+//     S: BaseNum,
+// {
+//     fn point3(self) -> Point3<S> {
+//         self
+//     }
+// }
+
+impl<V> Vertex3d for Rgba<V>
+where
+    V: Vertex3d,
+{
+    fn point3(self) -> Point3<V::Scalar> {
+        self.0.point3()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub extern crate daggy;
 pub extern crate find_folder;
 pub extern crate glium;
 pub extern crate rand;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,6 @@
 extern crate cgmath;
 pub use self::cgmath::*;
-
-use self::cgmath::num_traits::{NumCast, One};
+pub use self::cgmath::num_traits::{NumCast, One};
 use std::ops::Add;
 
 pub fn pt1<S>(x: S) -> Point1<S> {


### PR DESCRIPTION
The `geom::Graph` should be useful for composing together multiple
geometric primitives (tris, quads, cuboids, other graphs, etc). See the
`graph` and `Graph` documentation for more details. This should be
useful for building the `Graphics` API, combining a geometry graph with
some sort of colour and texture mapping for nodes/vertices.

Moves the `Vertex` traits into a `vertex` submodule.

Adds `Polygon`, `Ellipse` and `Quad` types that wrap their respective
module's functions with a single type.

Adds some missing iterator implementations to some primitive geom types.