### PR TITLE
[graphics] Add `mesh` mod for working with meshes with custom channels and layouts. Add `draw` mod with a high-level, expressive graphics API.

### DIFF
--- a/examples/simple_draw.rs
+++ b/examples/simple_draw.rs
@@ -1,0 +1,40 @@
+extern crate nannou;
+
+use nannou::prelude::*;
+
+fn main() {
+    nannou::run(model, event, view);
+}
+
+struct Model {
+    window: WindowId,
+}
+
+fn model(app: &App) -> Model {
+    let window = app.new_window().build().unwrap();
+    Model { window }
+}
+
+fn event(_app: &App, model: Model, _event: Event) -> Model {
+    model
+}
+
+fn view(app: &App, model: &Model, frame: Frame) -> Frame {
+    // Begin drawing 
+    let draw = app.draw(model.window).unwrap();
+
+    // Clear the background to blue.
+    draw.background().rgb(0.0, 0.0, 1.0);
+
+    // Short-hand helper functions.
+    draw.ellipse()
+        .x_y(app.mouse.x, app.mouse.y)
+        .w_h(app.window.width * 0.5, app.window.height * 0.5)
+        .rgb(1.0, 0.0, 0.0);
+
+    // Write the result of our drawing to the window's OpenGL frame.
+    draw.to_frame(app, &frame).unwrap();
+
+    // Return the drawn frame.
+    frame
+}

--- a/src/draw/backend/glium.rs
+++ b/src/draw/backend/glium.rs
@@ -1,0 +1,384 @@
+//! The `glium` backend for rendering the contents of a **Draw**'s mesh.
+
+use draw;
+use glium;
+use math::{BaseFloat, NumCast};
+use std::error::Error;
+use std::fmt;
+
+/// The `Vertex` type passed to the vertex shader.
+#[derive(Copy, Clone, Debug)]
+pub struct Vertex {
+    // /// The mode with which the `Vertex` will be drawn within the fragment shader.
+    // ///
+    // /// `0` for rendering text.
+    // /// `1` for rendering an image.
+    // /// `2` for rendering non-textured 2D geometry.
+    // ///
+    // /// If any other value is given, the fragment shader will not output any color.
+    // pub mode: u32,
+    
+    /// The position of the vertex within vector space.
+    ///
+    /// [-1.0, -1.0, 0.0] is the leftmost, bottom position of the display.
+    /// [1.0, 1.0, 0.0] is the rightmost, top position of the display.
+    pub position: [f32; 3],
+    /// A color associated with the `Vertex`.
+    ///
+    /// The way that the color is used depends on the `mode`.
+    pub color: [f32; 4],
+    /// The coordinates of the texture used by this `Vertex`.
+    ///
+    /// [0.0, 0.0] is the leftmost, bottom position of the texture.
+    /// [1.0, 1.0] is the rightmost, top position of the texture.
+    pub tex_coords: [f32; 2],
+}
+
+// /// Draw text from the text cache texture `tex` in the fragment shader.
+// pub const MODE_TEXT: u32 = 0;
+// /// Draw an image from the texture at `tex` in the fragment shader.
+// pub const MODE_IMAGE: u32 = 1;
+// /// Ignore `tex` and draw simple, colored 2D geometry.
+// pub const MODE_GEOMETRY: u32 = 2;
+
+#[allow(unsafe_code)]
+mod vertex_impl {
+    use super::Vertex;
+    implement_vertex!(Vertex, position, color, tex_coords);
+}
+
+impl Vertex {
+    /// Create a vertex from the given mesh vertex.
+    pub fn from_mesh_vertex<S>(
+        v: draw::mesh::Vertex<S>,
+        framebuffer_width: f32,
+        framebuffer_height: f32,
+        dpi_factor: f32,
+    ) -> Self
+    where
+        S: BaseFloat,
+    {
+        let point = v.point();
+        let x_f: f32 = NumCast::from(point.x).unwrap();
+        let y_f: f32 = NumCast::from(point.y).unwrap();
+        let z_f: f32 = NumCast::from(point.z).unwrap();
+        // Map coords from (-fb_dim, +fb_dim) to (-1.0, 1.0)
+        let x = 2.0 * x_f * dpi_factor / framebuffer_width;
+        let y = 2.0 * y_f * dpi_factor / framebuffer_height;
+        let z = 2.0 * z_f * dpi_factor / framebuffer_height;
+        let tex_x = NumCast::from(v.tex_coords.x).unwrap();
+        let tex_y = NumCast::from(v.tex_coords.y).unwrap();
+        let position = [x, y, z];
+        let color = [v.color.red, v.color.green, v.color.blue, v.color.alpha];
+        let tex_coords = [tex_x, tex_y];
+        Vertex { position, color, tex_coords }
+    }
+}
+
+// GLSL (ported from conrod)
+
+/// The vertex shader used within the `glium::Program` for OpenGL.
+pub const VERTEX_SHADER_120: &'static str = "
+    #version 120
+
+    attribute vec3 position;
+    attribute vec4 color;
+    attribute vec2 tex_coords;
+    // attribute float mode;
+
+    varying vec4 v_color;
+    varying vec2 v_tex_coords;
+    // varying float v_mode;
+
+    void main() {
+        gl_Position = vec4(position, 1.0);
+        v_color = color;
+        v_tex_coords = tex_coords;
+        // v_mode = mode;
+    }
+";
+
+/// The fragment shader used within the `glium::Program` for OpenGL.
+pub const FRAGMENT_SHADER_120: &'static str = "
+    #version 120
+    // uniform sampler2D tex;
+
+    varying vec2 v_tex_coords;
+    varying vec4 v_color;
+    // varying float v_mode;
+
+    void main() {
+        // // Text
+        // if (v_mode == 0.0) {
+        //     gl_FragColor = v_color * vec4(1.0, 1.0, 1.0, texture2D(tex, v_tex_coords).r);
+
+        // // Image
+        // } else if (v_mode == 1.0) {
+        //     gl_FragColor = texture2D(tex, v_tex_coords);
+
+        // // 2D Geometry
+        // } else if (v_mode == 2.0) {
+        //     gl_FragColor = v_color;
+        // }
+
+        gl_FragColor = v_color;
+    }
+";
+
+/// The vertex shader used within the `glium::Program` for OpenGL.
+pub const VERTEX_SHADER_140: &'static str = "
+    #version 140
+
+    in vec3 position;
+    in vec4 color;
+    in vec2 tex_coords;
+    // in uint mode;
+
+    out vec4 v_color;
+    out vec2 v_tex_coords;
+    // flat out uint v_mode;
+
+    void main() {
+        gl_Position = vec4(position, 1.0);
+        v_color = color;
+        v_tex_coords = tex_coords;
+        // v_mode = mode;
+    }
+";
+
+/// The fragment shader used within the `glium::Program` for OpenGL.
+pub const FRAGMENT_SHADER_140: &'static str = "
+    #version 140
+    // uniform sampler2D tex;
+
+    in vec4 v_color;
+    in vec2 v_tex_coords;
+    // flat in uint v_mode;
+
+    out vec4 f_color;
+
+    void main() {
+        // // Text
+        // if (v_mode == uint(0)) {
+        //     f_color = v_color * vec4(1.0, 1.0, 1.0, texture(tex, v_tex_coords).r);
+
+        // // Image
+        // } else if (v_mode == uint(1)) {
+        //     f_color = texture(tex, v_tex_coords);
+
+        // // 2D Geometry
+        // } else if (v_mode == uint(2)) {
+        //     f_color = v_color;
+        // }
+
+        f_color = v_color;
+    }
+";
+
+/// The vertex shader used within the `glium::Program` for OpenGL ES.
+pub const VERTEX_SHADER_300_ES: &'static str = "
+    #version 300 es
+    precision mediump float;
+
+    in vec3 position;
+    in vec4 color;
+    in vec2 tex_coords;
+    // in uint mode;
+
+    out vec4 v_color;
+    out vec2 v_tex_coords;
+    // flat out uint v_mode;
+
+    void main() {
+        gl_Position = vec4(position, 1.0);
+        v_color = color;
+        v_tex_coords = tex_coords;
+        // v_mode = mode;
+    }
+";
+
+/// The fragment shader used within the `glium::Program` for OpenGL ES.
+pub const FRAGMENT_SHADER_300_ES: &'static str = "
+    #version 300 es
+    precision mediump float;
+    // uniform sampler2D tex;
+
+    in vec4 v_color;
+    in vec2 v_tex_coords;
+    // flat in uint v_mode;
+
+    out vec4 f_color;
+
+    void main() {
+        // // Text
+        // if (v_mode == uint(0)) {
+        //     f_color = v_color * vec4(1.0, 1.0, 1.0, texture(tex, v_tex_coords).r);
+
+        // // Image
+        // } else if (v_mode == uint(1)) {
+        //     f_color = texture(tex, v_tex_coords);
+
+        // // 2D Geometry
+        // } else if (v_mode == uint(2)) {
+        //     f_color = v_color;
+        // }
+
+        f_color = v_color;
+    }
+";
+
+/// Construct the glium shader program that can be used to render `Vertex`es.
+pub fn program<F>(facade: &F) -> Result<glium::Program, glium::program::ProgramChooserCreationError>
+    where F: glium::backend::Facade,
+{
+    program!(facade,
+             120 => { vertex: VERTEX_SHADER_120, fragment: FRAGMENT_SHADER_120 },
+             140 => { vertex: VERTEX_SHADER_140, fragment: FRAGMENT_SHADER_140 },
+             300 es => { vertex: VERTEX_SHADER_300_ES, fragment: FRAGMENT_SHADER_300_ES })
+}
+
+/// Default glium `DrawParameters` with alpha blending enabled.
+pub fn draw_parameters() -> glium::DrawParameters<'static> {
+    let blend = glium::Blend::alpha_blending();
+    glium::DrawParameters { multisampling: true, blend: blend, ..Default::default() }
+}
+
+/// Errors that might occur during a call to `Renderer::draw`.
+#[derive(Debug)]
+pub enum RendererDrawError {
+    BufferCreation(BufferCreationError),
+    Draw(glium::DrawError),
+}
+
+#[derive(Debug)]
+pub enum BufferCreationError {
+    Vertex(glium::vertex::BufferCreationError),
+    Index(glium::index::BufferCreationError),
+}
+
+/// A type used for rendering a **nannou::draw::Mesh** to an OpenGL surface via glium.
+pub struct Renderer {
+    program: glium::Program,
+    vertices: Vec<Vertex>,
+    indices: Vec<u32>,
+}
+
+impl Renderer {
+    /// Build a new **nannou::draw::backend::glium::Renderer**.
+    pub fn new<F>(facade: &F) -> Result<Self, glium::program::ProgramChooserCreationError>
+    where
+        F: glium::backend::Facade,
+    {
+        let program = program(facade)?;
+        let vertices = vec![];
+        let indices = vec![];
+        Ok(Renderer { program, vertices, indices })
+    }
+
+    /// Draw the given mesh to the given glium surface.
+    pub fn draw<S, F, T>(
+        &mut self,
+        draw: &draw::Draw<S>,
+        facade: &F,
+        dpi_factor: f32,
+        surface: &mut T,
+    ) -> Result<(), RendererDrawError>
+    where
+        S: BaseFloat,
+        F: glium::backend::Facade,
+        T: glium::Surface,
+    {
+        // If some background color was given, clear the screen with it.
+        if let Some(color) = draw.state.borrow().background_color {
+            surface.clear_color(color.red, color.green, color.blue, color.alpha);
+        }
+
+        // Create the vertex and index buffers.
+        self.vertices.clear();
+        self.indices.clear();
+        let (w, h) = facade.get_context().get_framebuffer_dimensions();
+        let map_vertex = |v| Vertex::from_mesh_vertex(v, w as _, h as _, dpi_factor);
+        self.vertices.extend(draw.raw_vertices().map(map_vertex));
+        self.indices.extend(draw.mesh().indices().iter().map(|&u| u as u32));
+        let index_prim = glium::index::PrimitiveType::TrianglesList;
+        let vertex_buffer = glium::VertexBuffer::new(facade, &self.vertices[..])?;
+        let index_buffer = glium::IndexBuffer::new(facade, index_prim, &self.indices[..])?;
+
+        // Create the draw parameters.
+        let draw_params = draw_parameters();
+
+        // Create the uniforms.
+        let uniforms = uniform!{};
+
+        // Draw to the given surface.
+        surface.draw(&vertex_buffer, &index_buffer, &self.program, &uniforms, &draw_params)?;
+
+        Ok(())
+    }
+}
+
+impl Error for BufferCreationError {
+    fn description(&self) -> &str {
+        match *self {
+            BufferCreationError::Vertex(ref err) => err.description(),
+            BufferCreationError::Index(ref err) => err.description(),
+        }
+    }
+}
+
+impl Error for RendererDrawError {
+    fn description(&self) -> &str {
+        match *self {
+            RendererDrawError::BufferCreation(ref err) => err.description(),
+            RendererDrawError::Draw(ref err) => err.description(),
+        }
+    }
+}
+
+impl fmt::Display for BufferCreationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl fmt::Display for RendererDrawError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl From<glium::vertex::BufferCreationError> for BufferCreationError {
+    fn from(err: glium::vertex::BufferCreationError) -> Self {
+        BufferCreationError::Vertex(err)
+    }
+}
+
+impl From<glium::index::BufferCreationError> for BufferCreationError {
+    fn from(err: glium::index::BufferCreationError) -> Self {
+        BufferCreationError::Index(err)
+    }
+}
+
+impl From<BufferCreationError> for RendererDrawError {
+    fn from(err: BufferCreationError) -> Self {
+        RendererDrawError::BufferCreation(err)
+    }
+}
+
+impl From<glium::DrawError> for RendererDrawError {
+    fn from(err: glium::DrawError) -> Self {
+        RendererDrawError::Draw(err)
+    }
+}
+
+impl From<glium::vertex::BufferCreationError> for RendererDrawError {
+    fn from(err: glium::vertex::BufferCreationError) -> Self {
+        RendererDrawError::BufferCreation(err.into())
+    }
+}
+
+impl From<glium::index::BufferCreationError> for RendererDrawError {
+    fn from(err: glium::index::BufferCreationError) -> Self {
+        RendererDrawError::BufferCreation(err.into())
+    }
+}

--- a/src/draw/backend/mod.rs
+++ b/src/draw/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod glium;

--- a/src/draw/background.rs
+++ b/src/draw/background.rs
@@ -1,0 +1,66 @@
+use color::{self, Rgb, Rgba};
+use draw::Draw;
+use draw::properties::{ColorScalar, IntoRgba};
+use math::BaseFloat;
+
+/// A type used to update the background colour.
+pub struct Background<'a, S>
+where
+    S: 'a + BaseFloat,
+{
+    draw: &'a Draw<S>
+}
+
+/// Begin coloring the background.
+pub fn new<'a, S>(draw: &'a Draw<S>) -> Background<'a, S>
+where
+    S: BaseFloat,
+{
+    Background { draw }
+}
+
+impl<'a, S> Background<'a, S>
+where
+    S: BaseFloat,
+{
+    /// Clear the background with the given color.
+    ///
+    /// This method supports any color type that can be converted into RGBA.
+    ///
+    /// Colors that have no alpha channel will be given an opaque alpha channel value `1.0`.
+    pub fn color<C>(self, color: C) -> Self
+    where
+        C: IntoRgba<ColorScalar>,
+    {
+        if let Ok(mut state) = self.draw.state.try_borrow_mut() {
+            state.background_color = Some(color.into_rgba());
+        }
+        self
+    }
+
+    /// Specify the color via red, green and blue channels.
+    pub fn rgb(self, r: ColorScalar, g: ColorScalar, b: ColorScalar) -> Self {
+        self.color(Rgb::new(r, g, b))
+    }
+
+    /// Specify the color via red, green, blue and alpha channels.
+    pub fn rgba(self, r: ColorScalar, g: ColorScalar, b: ColorScalar, a: ColorScalar) -> Self {
+        self.color(Rgba::new(r, g, b, a))
+    }
+
+    /// Specify the color via hue, saturation and luminance.
+    pub fn hsl<H>(self, h: H, s: ColorScalar, l: ColorScalar) -> Self
+    where
+        H: Into<color::RgbHue<ColorScalar>>,
+    {
+        self.color(color::Hsl::new(h.into(), s, l))
+    }
+
+    /// Specify the color via hue, saturation, luminance and an alpha channel.
+    pub fn hsla<H>(self, h: H, s: ColorScalar, l: ColorScalar, a: ColorScalar) -> Self
+    where
+        H: Into<color::RgbHue<ColorScalar>>,
+    {
+        self.color(color::Hsla::new(h.into(), s, l, a))
+    }
+}

--- a/src/draw/drawing.rs
+++ b/src/draw/drawing.rs
@@ -1,0 +1,953 @@
+use draw::{self, Draw};
+use draw::properties::spatial::{dimension, position};
+use draw::properties::{ColorScalar, IntoDrawn, IntoRgba, Primitive, SetColor, SetDimensions, SetPosition};
+use geom;
+use geom::graph::node;
+use math::{BaseFloat, Point2, Point3, Vector2, Vector3};
+use std::marker::PhantomData;
+
+/// A **Drawing** in progress.
+///
+/// **Drawing** provides a way of chaining together method calls describing properties of the thing
+/// that we are drawing. **Drawing** ends when the instance is **Drop**ped, at which point the
+/// properties of the drawing are inserted into the **Draw** type.
+///
+/// When a **Drawing** begins, a node is immediately created for the drawing within the **Draw**'s
+/// inner **geom::Graph**. This ensures the correct instantiation order is maintained within the
+/// graph. As a result, each **Drawing** is associated with a single, unique node. Thus a
+/// **Drawing** can be thought of as a way of specifying properties for a node.
+#[derive(Debug)]
+pub struct Drawing<'a, T, S = geom::DefaultScalar>
+where
+    T: IntoDrawn<S>,
+    S: 'a + BaseFloat,
+{
+    // The `Draw` instance used to create this drawing.
+    draw: &'a Draw<S>,
+    // The `Index` of the node that was created.
+    //
+    // This may not be accessed by the user until drawing is complete. This is because the
+    // **Drawing** may yet describe further positioning, orientation or scaling and in turn using
+    // the index to refer to a node before these properties are set may yield unexpected behaviour.
+    index: node::Index,
+    // The node type currently being drawn.
+    _ty: PhantomData<T>,
+}
+
+/// Construct a new **Drawing** instance.
+pub fn new<'a, T, S>(draw: &'a Draw<S>, index: node::Index) -> Drawing<'a, T, S>
+where
+    T: IntoDrawn<S>,
+    S: BaseFloat,
+{
+    let _ty = PhantomData;
+    Drawing { draw, index, _ty }
+}
+
+impl<'a, T, S> Drop for Drawing<'a, T, S>
+where
+    T: IntoDrawn<S>,
+    S: BaseFloat,
+{
+    fn drop(&mut self) {
+        self.finish_inner()
+            .expect("the drawing contained a relative edge that would have caused a cycle within the geometry graph");
+    }
+}
+
+impl<'a, T, S> Drawing<'a, T, S>
+where
+    T: IntoDrawn<S>,
+    S: BaseFloat,
+{
+    // Shared between the **finish** method and the **Drawing**'s **Drop** implementation.
+    //
+    // 1. Create vertices based on node-specific position, points, etc.
+    // 2. Insert edges into geom graph based on
+    fn finish_inner(&mut self) -> Result<(), geom::graph::WouldCycle<S>> {
+        if let Ok(mut state) = self.draw.state.try_borrow_mut() {
+            if let Some(prim) = state.drawing.remove(&self.index) {
+                let index = self.index;
+                draw::draw_primitive(&mut state, index, prim)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Complete the drawing and insert it into the parent **Draw** instance.
+    ///
+    /// This will be called when the **Drawing** is **Drop**ped if it has not yet been called.
+    pub fn finish(mut self) -> Result<(), geom::graph::WouldCycle<S>> {
+        self.finish_inner()
+    }
+
+    /// Complete the drawing and return its unique identifier.
+    ///
+    /// **Panics** if adding the edge would cause a cycle in the graph.
+    pub fn id(self) -> node::Index {
+        let id = self.index;
+        self.finish().expect(draw::WOULD_CYCLE);
+        id
+    }
+
+    // Map the given function onto the primitive stored within **Draw** at `index`.
+    //
+    // The functionn is only applied if the node has not yet been **Drawn**.
+    fn map_primitive<F>(self, map: F) -> Self
+    where
+        F: FnOnce(draw::properties::Primitive<S>) -> draw::properties::Primitive<S>,
+    {
+        if let Ok(mut state) = self.draw.state.try_borrow_mut() {
+            if let Some(mut primitive) = state.drawing.remove(&self.index) {
+                primitive = map(primitive);
+                state.drawing.insert(self.index, primitive);
+            }
+        }
+        self
+    }
+
+    // Map the given function onto the type stored within **Draw** at `index`.
+    //
+    // The functionn is only applied if the node has not yet been **Drawn**.
+    //
+    // **Panics** if the primitive does not contain type **T**.
+    fn map_ty<F>(self, map: F) -> Self
+    where
+        F: FnOnce(T) -> T,
+        T: Into<Primitive<S>>,
+        Primitive<S>: Into<Option<T>>,
+    {
+        self.map_primitive(|prim| {
+            let maybe_ty: Option<T> = prim.into();
+            let mut ty = maybe_ty.expect("expected `T` but primitive contained different type");
+            ty = map(ty);
+            ty.into()
+        })
+    }
+}
+
+// SetColor implementations.
+
+impl<'a, T, S> Drawing<'a, T, S>
+where
+    T: IntoDrawn<S> + SetColor<ColorScalar> + Into<Primitive<S>>,
+    Primitive<S>: Into<Option<T>>,
+    S: BaseFloat,
+{
+    /// Specify a color.
+    ///
+    /// This method supports any color type that can be converted into RGBA.
+    ///
+    /// Colors that have no alpha channel will be given an opaque alpha channel value `1.0`.
+    pub fn color<C>(self, color: C) -> Self
+    where
+        C: IntoRgba<ColorScalar>,
+    {
+        self.map_ty(|ty| SetColor::color(ty, color))
+    }
+
+    /// Specify the color via red, green and blue channels.
+    pub fn rgb(self, r: ColorScalar, g: ColorScalar, b: ColorScalar) -> Self {
+        self.map_ty(|ty| SetColor::rgb(ty, r, g, b))
+    }
+
+    /// Specify the color via red, green, blue and alpha channels.
+    pub fn rgba(self, r: ColorScalar, g: ColorScalar, b: ColorScalar, a: ColorScalar) -> Self {
+        self.map_ty(|ty| SetColor::rgba(ty, r, g, b, a))
+    }
+
+    /// Specify the color via hue, saturation and luminance.
+    pub fn hsl<H>(self, h: H, s: ColorScalar, l: ColorScalar) -> Self
+    where
+        H: Into<::color::RgbHue<ColorScalar>>,
+    {
+        self.map_ty(|ty| SetColor::hsl(ty, h, s, l))
+    }
+
+    /// Specify the color via hue, saturation, luminance and an alpha channel.
+    pub fn hsla<H>(self, h: H, s: ColorScalar, l: ColorScalar, a: ColorScalar) -> Self
+    where
+        H: Into<::color::RgbHue<ColorScalar>>,
+    {
+        self.map_ty(|ty| SetColor::hsla(ty, h, s, l, a))
+    }
+}
+
+// SetDimensions implementations.
+
+impl<'a, T, S> Drawing<'a, T, S>
+where
+    T: IntoDrawn<S> + SetDimensions<S> + Into<Primitive<S>>,
+    Primitive<S>: Into<Option<T>>,
+    S: BaseFloat,
+{
+    // Setters for each axis.
+
+    /// Set the length along the x axis.
+    pub fn x_dimension(self, x: dimension::Dimension<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::x_dimension(ty, x))
+    }
+
+    /// Set the length along the y axis.
+    pub fn y_dimension(self, y: dimension::Dimension<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::y_dimension(ty, y))
+    }
+
+    /// Set the length along the z axis.
+    pub fn z_dimension(self, z: dimension::Dimension<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::z_dimension(ty, z))
+    }
+
+    // Absolute dimensions.
+
+    /// Set the absolute width for the node.
+    pub fn width(self, w: S) -> Self {
+        self.map_ty(|ty| SetDimensions::width(ty, w))
+    }
+
+    /// Set the absolute height for the node.
+    pub fn height(self, h: S) -> Self {
+        self.map_ty(|ty| SetDimensions::height(ty, h))
+    }
+
+    /// Set the absolute depth for the node.
+    pub fn depth(self, d: S) -> Self {
+        self.map_ty(|ty| SetDimensions::depth(ty, d))
+    }
+
+    /// Short-hand for the **width** method.
+    pub fn w(self, w: S) -> Self {
+        self.map_ty(|ty| SetDimensions::w(ty, w))
+    }
+
+    /// Short-hand for the **height** method.
+    pub fn h(self, h: S) -> Self {
+        self.map_ty(|ty| SetDimensions::h(ty, h))
+    }
+
+    /// Short-hand for the **depth** method.
+    pub fn d(self, d: S) -> Self {
+        self.map_ty(|ty| SetDimensions::d(ty, d))
+    }
+
+    /// Set the **x** and **y** dimensions for the node.
+    pub fn wh(self, v: Vector2<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::wh(ty, v))
+    }
+
+    /// Set the **x**, **y** and **z** dimensions for the node.
+    pub fn whd(self, v: Vector3<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::whd(ty, v))
+    }
+
+    /// Set the width and height for the node.
+    pub fn w_h(self, x: S, y: S) -> Self {
+        self.map_ty(|ty| SetDimensions::w_h(ty, x, y))
+    }
+
+    /// Set the width and height for the node.
+    pub fn w_h_d(self, x: S, y: S, z: S) -> Self {
+        self.map_ty(|ty| SetDimensions::w_h_d(ty, x, y, z))
+    }
+
+    // Relative dimensions.
+
+    /// Some relative dimension along the **x** axis.
+    pub fn x_dimension_relative(self, other: node::Index, x: dimension::Relative<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::x_dimension_relative(ty, other, x))
+    }
+
+    /// Some relative dimension along the **y** axis.
+    pub fn y_dimension_relative(self, other: node::Index, y: dimension::Relative<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::y_dimension_relative(ty, other, y))
+    }
+
+    /// Some relative dimension along the **z** axis.
+    pub fn z_dimension_relative(self, other: node::Index, z: dimension::Relative<S>) -> Self {
+        self.map_ty(|ty| SetDimensions::z_dimension_relative(ty, other, z))
+    }
+
+    /// Set the x-axis dimension as the width of the node at the given index.
+    pub fn w_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetDimensions::w_of(ty, other))
+    }
+
+    /// Set the y-axis dimension as the height of the node at the given index.
+    pub fn h_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetDimensions::h_of(ty, other))
+    }
+
+    /// Set the z-axis dimension as the depth of the node at the given index.
+    pub fn d_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetDimensions::d_of(ty, other))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index.
+    pub fn wh_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetDimensions::wh_of(ty, other))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index.
+    pub fn whd_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetDimensions::whd_of(ty, other))
+    }
+
+    /// Set the width as the width of the node at the given index padded at both ends by the
+    /// given Scalar.
+    pub fn padded_w_of(self, other: node::Index, pad: S) -> Self {
+        self.map_ty(|ty| SetDimensions::padded_w_of(ty, other, pad))
+    }
+
+    /// Set the height as the height of the node at the given index padded at both ends by the
+    /// given Scalar.
+    pub fn padded_h_of(self, other: node::Index, pad: S) -> Self {
+        self.map_ty(|ty| SetDimensions::padded_h_of(ty, other, pad))
+    }
+
+    /// Set the depth as the depth of the node at the given index padded at both ends by the
+    /// given Scalar.
+    pub fn padded_d_of(self, other: node::Index, pad: S) -> Self {
+        self.map_ty(|ty| SetDimensions::padded_d_of(ty, other, pad))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index with each dimension
+    /// padded by the given scalar.
+    pub fn padded_wh_of(self, other: node::Index, pad: S) -> Self
+    where
+        S: Clone,
+    {
+        self.map_ty(|ty| SetDimensions::padded_wh_of(ty, other, pad))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index with each dimension
+    /// padded by the given scalar.
+    pub fn padded_whd_of(self, other: node::Index, pad: S) -> Self
+    where
+        S: Clone,
+    {
+        self.map_ty(|ty| SetDimensions::padded_whd_of(ty, other, pad))
+    }
+
+    /// Set the width as the width of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    pub fn scaled_w_of(self, other: node::Index, scale: S) -> Self {
+        self.map_ty(|ty| SetDimensions::scaled_w_of(ty, other, scale))
+    }
+
+    /// Set the height as the height of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    pub fn scaled_h_of(self, other: node::Index, scale: S) -> Self {
+        self.map_ty(|ty| SetDimensions::scaled_h_of(ty, other, scale))
+    }
+
+    /// Set the depth as the depth of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    pub fn scaled_d_of(self, other: node::Index, scale: S) -> Self {
+        self.map_ty(|ty| SetDimensions::scaled_d_of(ty, other, scale))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index multiplied by the given
+    /// **scale** Scalar value.
+    pub fn scaled_wh_of(self, other: node::Index, scale: S) -> Self
+    where
+        S: Clone,
+    {
+        self.map_ty(|ty| SetDimensions::scaled_wh_of(ty, other, scale))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index multiplied by the given
+    /// **scale** Scalar value.
+    pub fn scaled_whd_of(self, other: node::Index, scale: S) -> Self
+    where
+        S: Clone,
+    {
+        self.map_ty(|ty| SetDimensions::scaled_whd_of(ty, other, scale))
+    }
+}
+
+// SetPosition methods.
+
+impl<'a, T, S> Drawing<'a, T, S>
+where
+    T: IntoDrawn<S> + SetPosition<S> + Into<Primitive<S>>,
+    Primitive<S>: Into<Option<T>>,
+    S: BaseFloat,
+{
+    /// Build with the given **Position** along the *x* axis.
+    pub fn x_position(self, position: position::Position<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_position(ty, position))
+    }
+
+    /// Build with the given **Position** along the *y* axis.
+    pub fn y_position(self, position: position::Position<S>) -> Self {
+        self.map_ty(|ty| SetPosition::y_position(ty, position))
+    }
+
+    /// Build with the given **Position** along the *z* axis.
+    pub fn z_position(self, position: position::Position<S>) -> Self {
+        self.map_ty(|ty| SetPosition::z_position(ty, position))
+    }
+
+    // Absolute positioning.
+
+    /// Build with the given **Absolute** **Position** along the *x* axis.
+    pub fn x(self, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::x(ty, x))
+    }
+
+    /// Build with the given **Absolute** **Position** along the *y* axis.
+    pub fn y(self, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::y(ty, y))
+    }
+
+    /// Build with the given **Absolute** **Position** along the *z* axis.
+    pub fn z(self, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::z(ty, z))
+    }
+
+    /// Set the **Position** with some two-dimensional point.
+    pub fn xy(self, p: Point2<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xy(ty, p))
+    }
+
+    /// Set the **Position** with some three-dimensional point.
+    pub fn xyz(self, p: Point3<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xyz(ty, p))
+    }
+
+    /// Set the **Position** with *x* *y* coordinates.
+    pub fn x_y(self, x: S, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y(ty, x, y))
+    }
+
+    /// Set the **Position** with *x* *y* *z* coordinates.
+    pub fn x_y_z(self, x: S, y: S, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_z(ty, x, y, z))
+    }
+
+    // Relative positioning.
+
+    /// Set the *x* **Position** **Relative** to the previous node.
+    pub fn x_position_relative(self, x: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_position_relative(ty, x))
+    }
+
+    /// Set the *y* **Position** **Relative** to the previous node.
+    pub fn y_position_relative(self, y: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::y_position_relative(ty, y))
+    }
+
+    /// Set the *z* **Position** **Relative** to the previous node.
+    pub fn z_position_relative(self, z: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::z_position_relative(ty, z))
+    }
+
+    /// Set the *x* and *y* **Position**s **Relative** to the previous node.
+    pub fn x_y_position_relative(self, x: position::Relative<S>, y: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_position_relative(ty, x, y))
+    }
+
+    /// Set the *x*, *y* and *z* **Position**s **Relative** to the previous node.
+    pub fn x_y_z_position_relative(
+        self,
+        x: position::Relative<S>,
+        y: position::Relative<S>,
+        z: position::Relative<S>,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_z_position_relative(ty, x, y, z))
+    }
+
+    /// Set the *x* **Position** **Relative** to the given node.
+    pub fn x_position_relative_to(self, other: node::Index, x: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_position_relative_to(ty, other, x))
+    }
+
+    /// Set the *y* **Position** **Relative** to the given node.
+    pub fn y_position_relative_to(self, other: node::Index, y: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::y_position_relative_to(ty, other, y))
+    }
+
+    /// Set the *y* **Position** **Relative** to the given node.
+    pub fn z_position_relative_to(self, other: node::Index, z: position::Relative<S>) -> Self {
+        self.map_ty(|ty| SetPosition::z_position_relative_to(ty, other, z))
+    }
+
+    /// Set the *x* and *y* **Position**s **Relative** to the given node.
+    pub fn x_y_position_relative_to(
+        self,
+        other: node::Index,
+        x: position::Relative<S>,
+        y: position::Relative<S>,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_position_relative_to(ty, other, x, y))
+    }
+
+    /// Set the *x*, *y* and *z* **Position**s **Relative** to the given node.
+    pub fn x_y_z_position_relative_to(
+        self,
+        other: node::Index,
+        x: position::Relative<S>,
+        y: position::Relative<S>,
+        z: position::Relative<S>,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_z_position_relative_to(ty, other, x, y, z))
+    }
+
+    // Relative `Scalar` positioning.
+
+    /// Set the **Position** as a **Scalar** along the *x* axis **Relative** to the middle of
+    /// previous node.
+    pub fn x_relative(self, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_relative(ty, x))
+    }
+
+    /// Set the **Position** as a **Scalar** along the *y* axis **Relative** to the middle of
+    /// previous node.
+    pub fn y_relative(self, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::y_relative(ty, y))
+    }
+
+    /// Set the **Position** as a **Scalar** along the *z* axis **Relative** to the middle of
+    /// previous node.
+    pub fn z_relative(self, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::z_relative(ty, z))
+    }
+
+    /// Set the **Position** as a **Point** **Relative** to the middle of the previous node.
+    pub fn xy_relative(self, p: Point2<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xy_relative(ty, p))
+    }
+
+    /// Set the **Position** as a **Point** **Relative** to the middle of the previous node.
+    pub fn xyz_relative(self, p: Point3<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xyz_relative(ty, p))
+    }
+
+    /// Set the **Position** as **Scalar**s along the *x* and *y* axes **Relative** to the middle
+    /// of the previous node.
+    pub fn x_y_relative(self, x: S, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_relative(ty, x, y))
+    }
+
+    /// Set the **Position** as **Scalar**s along the *x*, *y* and *z* axes **Relative** to the
+    /// middle of the previous node.
+    pub fn x_y_z_relative(self, x: S, y: S, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_z_relative(ty, x, y, z))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn x_relative_to(self, other: node::Index, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_relative_to(ty, other, x))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn y_relative_to(self, other: node::Index, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::y_relative_to(ty, other, y))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn z_relative_to(self, other: node::Index, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::z_relative_to(ty, other, z))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn xy_relative_to(self, other: node::Index, p: Point2<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xy_relative_to(ty, other, p))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn xyz_relative_to(self, other: node::Index, p: Point3<S>) -> Self {
+        self.map_ty(|ty| SetPosition::xyz_relative_to(ty, other, p))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn x_y_relative_to(self, other: node::Index, x: S, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_relative_to(ty, other, x, y))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    pub fn x_y_z_relative_to(self, other: node::Index, x: S, y: S, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_y_z_relative_to(ty, other, x, y, z))
+    }
+
+    // Directional positioning.
+
+    /// Build with the **Position** along the *x* axis as some distance from another node.
+    pub fn x_direction(self, direction: position::Direction, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::x_direction(ty, direction, x))
+    }
+
+    /// Build with the **Position** along the *y* axis as some distance from another node.
+    pub fn y_direction(self, direction: position::Direction, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::y_direction(ty, direction, y))
+    }
+
+    /// Build with the **Position** along the *z* axis as some distance from another node.
+    pub fn z_direction(self, direction: position::Direction, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::z_direction(ty, direction, z))
+    }
+
+    /// Build with the **Position** as some distance to the left of another node.
+    pub fn left(self, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::left(ty, x))
+    }
+
+    /// Build with the **Position** as some distance to the right of another node.
+    pub fn right(self, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::right(ty, x))
+    }
+
+    /// Build with the **Position** as some distance below another node.
+    pub fn down(self, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::down(ty, y))
+    }
+
+    /// Build with the **Position** as some distance above another node.
+    pub fn up(self, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::up(ty, y))
+    }
+
+    /// Build with the **Position** as some distance in front of another node.
+    pub fn backwards(self, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::backwards(ty, z))
+    }
+
+    /// Build with the **Position** as some distance behind another node.
+    pub fn forwards(self, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::forwards(ty, z))
+    }
+
+    /// Build with the **Position** along the *x* axis as some distance from the given node.
+    pub fn x_direction_from(
+        self,
+        other: node::Index,
+        direction: position::Direction,
+        x: S,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::x_direction_from(ty, other, direction, x))
+    }
+
+    /// Build with the **Position** along the *y* axis as some distance from the given node.
+    pub fn y_direction_from(
+        self,
+        other: node::Index,
+        direction: position::Direction,
+        y: S,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::y_direction_from(ty, other, direction, y))
+    }
+
+    /// Build with the **Position** along the *z* axis as some distance from the given node.
+    pub fn z_direction_from(
+        self,
+        other: node::Index,
+        direction: position::Direction,
+        z: S,
+    ) -> Self {
+        self.map_ty(|ty| SetPosition::z_direction_from(ty, other, direction, z))
+    }
+
+    /// Build with the **Position** as some distance to the left of the given node.
+    pub fn left_from(self, other: node::Index, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::left_from(ty, other, x))
+    }
+
+    /// Build with the **Position** as some distance to the right of the given node.
+    pub fn right_from(self, other: node::Index, x: S) -> Self {
+        self.map_ty(|ty| SetPosition::right_from(ty, other, x))
+    }
+
+    /// Build with the **Position** as some distance below the given node.
+    pub fn down_from(self, other: node::Index, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::down_from(ty, other, y))
+    }
+
+    /// Build with the **Position** as some distance above the given node.
+    pub fn up_from(self, other: node::Index, y: S) -> Self {
+        self.map_ty(|ty| SetPosition::up_from(ty, other, y))
+    }
+
+    /// Build with the **Position** as some distance in front of the given node.
+    pub fn backwards_from(self, other: node::Index, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::backwards_from(ty, other, z))
+    }
+
+    /// Build with the **Position** as some distance above the given node.
+    pub fn forwards_from(self, other: node::Index, z: S) -> Self {
+        self.map_ty(|ty| SetPosition::forwards_from(ty, other, z))
+    }
+
+    // Alignment positioning.
+
+    /// Align the **Position** of the node along the *x* axis.
+    pub fn x_align(self, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_align(ty, align))
+    }
+
+    /// Align the **Position** of the node along the *y* axis.
+    pub fn y_align(self, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::y_align(ty, align))
+    }
+
+    /// Align the **Position** of the node along the *z* axis.
+    pub fn z_align(self, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::z_align(ty, align))
+    }
+
+    /// Align the position to the left.
+    pub fn align_left(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_left(ty))
+    }
+
+    /// Align the position to the left.
+    pub fn align_left_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_left_with_margin(ty, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_x(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_x(ty))
+    }
+
+    /// Align the position to the right.
+    pub fn align_right(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_right(ty))
+    }
+
+    /// Align the position to the right.
+    pub fn align_right_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_right_with_margin(ty, margin))
+    }
+
+    /// Align the position to the bottom.
+    pub fn align_bottom(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_bottom(ty))
+    }
+
+    /// Align the position to the bottom.
+    pub fn align_bottom_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_bottom_with_margin(ty, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_y(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_y(ty))
+    }
+
+    /// Align the position to the top.
+    pub fn align_top(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_top(ty))
+    }
+
+    /// Align the position to the top.
+    pub fn align_top_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_top_with_margin(ty, margin))
+    }
+
+    /// Align the position to the front.
+    pub fn align_front(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_front(ty))
+    }
+
+    /// Align the position to the front.
+    pub fn align_front_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_front_with_margin(ty, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_z(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_z(ty))
+    }
+
+    /// Align the position to the back.
+    pub fn align_back(self) -> Self {
+        self.map_ty(|ty| SetPosition::align_back(ty))
+    }
+
+    /// Align the position to the back.
+    pub fn align_back_with_margin(self, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_back_with_margin(ty, margin))
+    }
+
+    /// Align the **Position** of the node with the given node along the *x* axis.
+    pub fn x_align_to(self, other: node::Index, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::x_align_to(ty, other, align))
+    }
+
+    /// Align the **Position** of the node with the given node along the *y* axis.
+    pub fn y_align_to(self, other: node::Index, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::y_align_to(ty, other, align))
+    }
+
+    /// Align the **Position** of the node with the given node along the *z* axis.
+    pub fn z_align_to(self, other: node::Index, align: position::Align<S>) -> Self {
+        self.map_ty(|ty| SetPosition::z_align_to(ty, other, align))
+    }
+
+    /// Align the position to the left.
+    pub fn align_left_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_left_of(ty, other))
+    }
+
+    /// Align the position to the left.
+    pub fn align_left_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_left_of_with_margin(ty, other, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_x_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_x_of(ty, other))
+    }
+
+    /// Align the position to the right.
+    pub fn align_right_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_right_of(ty, other))
+    }
+
+    /// Align the position to the right.
+    pub fn align_right_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_right_of_with_margin(ty, other, margin))
+    }
+
+    /// Align the position to the bottom.
+    pub fn align_bottom_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_bottom_of(ty, other))
+    }
+
+    /// Align the position to the bottom.
+    pub fn align_bottom_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_bottom_of_with_margin(ty, other, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_y_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_y_of(ty, other))
+    }
+
+    /// Align the position to the top.
+    pub fn align_top_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_top_of(ty, other))
+    }
+
+    /// Align the position to the top.
+    pub fn align_top_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_top_of_with_margin(ty, other, margin))
+    }
+
+    /// Align the position to the front.
+    pub fn align_front_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_front_of(ty, other))
+    }
+
+    /// Align the position to the front.
+    pub fn align_front_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_front_of_with_margin(ty, other, margin))
+    }
+
+    /// Align the position to the middle.
+    pub fn align_middle_z_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_middle_z_of(ty, other))
+    }
+
+    /// Align the position to the back.
+    pub fn align_back_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::align_back_of(ty, other))
+    }
+
+    /// Align the position to the back.
+    pub fn align_back_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.map_ty(|ty| SetPosition::align_back_of_with_margin(ty, other, margin))
+    }
+
+    // Alignment combinations.
+
+    /// Align the node to the middle of the last node.
+    pub fn middle(self) -> Self {
+        self.map_ty(|ty| SetPosition::middle(ty))
+    }
+
+    /// Align the node to the bottom left of the last node.
+    pub fn bottom_left(self) -> Self {
+        self.map_ty(|ty| SetPosition::bottom_left(ty))
+    }
+
+    /// Align the node to the middle left of the last node.
+    pub fn mid_left(self) -> Self {
+        self.map_ty(|ty| SetPosition::mid_left(ty))
+    }
+
+    /// Align the node to the top left of the last node.
+    pub fn top_left(self) -> Self {
+        self.map_ty(|ty| SetPosition::top_left(ty))
+    }
+
+    /// Align the node to the middle top of the last node.
+    pub fn mid_top(self) -> Self {
+        self.map_ty(|ty| SetPosition::mid_top(ty))
+    }
+
+    /// Align the node to the top right of the last node.
+    pub fn top_right(self) -> Self {
+        self.map_ty(|ty| SetPosition::top_right(ty))
+    }
+
+    /// Align the node to the middle right of the last node.
+    pub fn mid_right(self) -> Self {
+        self.map_ty(|ty| SetPosition::mid_right(ty))
+    }
+
+    /// Align the node to the bottom right of the last node.
+    pub fn bottom_right(self) -> Self {
+        self.map_ty(|ty| SetPosition::bottom_right(ty))
+    }
+
+    /// Align the node to the middle bottom of the last node.
+    pub fn mid_bottom(self) -> Self {
+        self.map_ty(|ty| SetPosition::mid_bottom(ty))
+    }
+
+    /// Align the node in the middle of the given Node.
+    pub fn middle_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::middle_of(ty, other))
+    }
+
+    /// Align the node to the bottom left of the given Node.
+    pub fn bottom_left_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::bottom_left_of(ty, other))
+    }
+
+    /// Align the node to the middle left of the given Node.
+    pub fn mid_left_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::mid_left_of(ty, other))
+    }
+
+    /// Align the node to the top left of the given Node.
+    pub fn top_left_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::top_left_of(ty, other))
+    }
+
+    /// Align the node to the middle top of the given Node.
+    pub fn mid_top_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::mid_top_of(ty, other))
+    }
+
+    /// Align the node to the top right of the given Node.
+    pub fn top_right_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::top_right_of(ty, other))
+    }
+
+    /// Align the node to the middle right of the given Node.
+    pub fn mid_right_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::mid_right_of(ty, other))
+    }
+
+    /// Align the node to the bottom right of the given Node.
+    pub fn bottom_right_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::bottom_right_of(ty, other))
+    }
+
+    /// Align the node to the middle bottom of the given Node.
+    pub fn mid_bottom_of(self, other: node::Index) -> Self {
+        self.map_ty(|ty| SetPosition::mid_bottom_of(ty, other))
+    }
+}

--- a/src/draw/mesh/mod.rs
+++ b/src/draw/mesh/mod.rs
@@ -1,0 +1,258 @@
+//! Items related to the custom mesh type used by the `Draw` API.
+
+use geom;
+use math::{BaseFloat, BaseNum};
+use mesh::{self, MeshPoints, WithColors, WithIndices, WithTexCoords};
+use std::ops::{Deref, DerefMut};
+
+pub mod vertex;
+
+pub use self::vertex::Vertex;
+
+pub type Points<S> = Vec<vertex::Point<S>>;
+pub type Indices = Vec<usize>;
+pub type Colors = Vec<vertex::Color>;
+pub type TexCoords<S> = Vec<vertex::TexCoords<S>>;
+
+/// The inner mesh type used by the **draw::Mesh**.
+pub type MeshType<S> =
+    WithTexCoords<WithColors<WithIndices<MeshPoints<Points<S>>, Indices>, Colors>, TexCoords<S>, S>;
+
+/// The custom mesh type used internally by the **Draw** API.
+#[derive(Clone, Debug)]
+pub struct Mesh<S = geom::DefaultScalar> {
+    mesh: MeshType<S>,
+}
+
+impl<S> Mesh<S>
+where
+    S: BaseNum,
+{
+    /// The number of raw vertices contained within the mesh.
+    pub fn raw_vertex_count(&self) -> usize {
+        mesh::raw_vertex_count(self)
+    }
+
+    /// The number of vertices that would be yielded by a **Vertices** iterator for the given mesh.
+    pub fn vertex_count(&self) -> usize {
+        mesh::vertex_count(self)
+    }
+
+    /// The number of triangles that would be yielded by a **Triangles** iterator for the given mesh.
+    pub fn triangle_count(&self) -> usize {
+        mesh::triangle_count(self)
+    }
+
+    /// The **Mesh**'s vertex position channel.
+    pub fn points(&self) -> &[vertex::Point<S>] {
+        mesh::Points::points(self)
+    }
+
+    /// The **Mesh**'s vertex indices channel.
+    pub fn indices(&self) -> &[usize] {
+        mesh::Indices::indices(self)
+    }
+
+    /// The **Mesh**'s vertex colors channel.
+    pub fn colors(&self) -> &[vertex::Color] {
+        mesh::Colors::colors(self)
+    }
+
+    /// The **Mesh**'s vertex texture coordinates channel.
+    pub fn tex_coords(&self) -> &[vertex::TexCoords<S>]
+    where
+        S: BaseFloat,
+    {
+        mesh::TexCoords::tex_coords(self)
+    }
+
+    /// Push the given vertex onto the inner channels.
+    pub fn push_vertex(&mut self, v: Vertex<S>) {
+        mesh::push_vertex(self, v);
+    }
+
+    /// Push the given index onto the inner **Indices** channel.
+    pub fn push_index(&mut self, i: usize) {
+        mesh::push_index(self, i);
+    }
+
+    /// Extend the mesh channels with the given vertices.
+    pub fn extend_vertices<I>(&mut self, vs: I)
+    where
+        I: IntoIterator<Item = Vertex<S>>,
+    {
+        mesh::extend_vertices(self, vs);
+    }
+
+    /// Extend the **Mesh** indices channel with the given indices.
+    pub fn extend_indices<I>(&mut self, is: I)
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        mesh::extend_indices(self, is);
+    }
+
+    /// Extend the **Mesh** with the given vertices and indices.
+    pub fn extend<V, I>(&mut self, vs: V, is: I)
+    where
+        V: IntoIterator<Item = Vertex<S>>,
+        I: IntoIterator<Item = usize>,
+    {
+        self.extend_vertices(vs);
+        self.extend_indices(is);
+    }
+
+    /// Clear all vertices from the mesh.
+    pub fn clear_vertices(&mut self) {
+        mesh::clear_vertices(self);
+    }
+
+    /// Clear all indices from the mesh.
+    pub fn clear_indices(&mut self) {
+        mesh::clear_indices(self);
+    }
+
+    /// Clear all vertices and indices from the mesh.
+    pub fn clear(&mut self) {
+        mesh::clear(self);
+    }
+
+    /// Produce an iterator yielding all raw (non-index-order) vertices.
+    pub fn raw_vertices(&self) -> mesh::RawVertices<&Self> {
+        mesh::raw_vertices(self)
+    }
+
+    /// Produce an iterator yielding all vertices in the order specified via the vertex indices.
+    pub fn vertices(&self) -> mesh::Vertices<&Self> {
+        mesh::vertices(self)
+    }
+
+    /// Produce an iterator yielding all triangles.
+    pub fn triangles(&self) -> mesh::Triangles<&Self> {
+        mesh::triangles(self)
+    }
+
+    /// Consume self and produce an iterator yielding all raw (non-index_order) vertices.
+    pub fn into_raw_vertices(self) -> mesh::RawVertices<Self> {
+        mesh::raw_vertices(self)
+    }
+
+    /// Consume self and produce an iterator yielding all vertices in index-order.
+    pub fn into_vertices(self) -> mesh::Vertices<Self> {
+        mesh::vertices(self)
+    }
+
+    /// Consume self and produce an iterator yielding all triangles.
+    pub fn into_triangles(self) -> mesh::Triangles<Self> {
+        mesh::triangles(self)
+    }
+}
+
+impl<S> Default for Mesh<S> {
+    fn default() -> Self {
+        let mesh = Default::default();
+        Mesh { mesh }
+    }
+}
+
+impl<S> Deref for Mesh<S> {
+    type Target = MeshType<S>;
+    fn deref(&self) -> &Self::Target {
+        &self.mesh
+    }
+}
+
+impl<S> DerefMut for Mesh<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mesh
+    }
+}
+
+impl<S> mesh::GetVertex for Mesh<S>
+where
+    MeshType<S>: mesh::GetVertex<Vertex = Vertex<S>>,
+{
+    type Vertex = Vertex<S>;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.mesh.get_vertex(index)
+    }
+}
+
+impl<S> mesh::Points for Mesh<S>
+where
+    S: BaseNum,
+{
+    type Scalar = S;
+    type Point = vertex::Point<S>;
+    type Points = Points<S>;
+    fn points(&self) -> &Self::Points {
+        self.mesh.points()
+    }
+}
+
+impl<S> mesh::Indices for Mesh<S> {
+    type Indices = Indices;
+    fn indices(&self) -> &Self::Indices {
+        self.mesh.indices()
+    }
+}
+
+impl<S> mesh::Colors for Mesh<S> {
+    type Color = vertex::Color;
+    type Colors = Colors;
+    fn colors(&self) -> &Self::Colors {
+        self.mesh.colors()
+    }
+}
+
+impl<S> mesh::TexCoords for Mesh<S>
+where
+    S: BaseFloat,
+{
+    type TexCoordScalar = S;
+    type TexCoords = TexCoords<S>;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        self.mesh.tex_coords()
+    }
+}
+
+impl<S> mesh::PushVertex<Vertex<S>> for Mesh<S> {
+    fn push_vertex(&mut self, v: Vertex<S>) {
+        self.mesh.push_vertex(v);
+    }
+}
+
+impl<S> mesh::PushIndex for Mesh<S> {
+    fn push_index(&mut self, index: usize) {
+        self.mesh.push_index(index);
+    }
+
+    fn extend_indices<I>(&mut self, indices: I)
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        self.mesh.extend_indices(indices);
+    }
+}
+
+impl<S> mesh::ClearIndices for Mesh<S> {
+    fn clear_indices(&mut self) {
+        self.mesh.clear_indices();
+    }
+}
+
+impl<S> mesh::ClearVertices for Mesh<S> {
+    fn clear_vertices(&mut self) {
+        self.mesh.clear_vertices();
+    }
+}
+
+#[test]
+fn test_method_access() {
+    let mesh: Mesh = Default::default();
+    assert_eq!(None, mesh::GetVertex::get_vertex(&mesh, 0));
+    mesh::Points::points(&mesh);
+    mesh::Indices::indices(&mesh);
+    mesh::Colors::colors(&mesh);
+    mesh::TexCoords::tex_coords(&mesh);
+}

--- a/src/draw/mesh/vertex.rs
+++ b/src/draw/mesh/vertex.rs
@@ -1,0 +1,196 @@
+use color;
+use geom;
+use math::{BaseFloat, Point2, Point3, Vector3};
+use mesh::vertex::{WithColor, WithTexCoords};
+use std::marker::PhantomData;
+
+pub type Point<S> = Point3<S>;
+pub type Color = color::Rgba;
+pub type TexCoords<S> = Point2<S>;
+pub type Normal<S> = Vector3<S>;
+
+/// The vertex type produced by the **draw::Mesh**'s inner **MeshType**.
+pub type Vertex<S> = WithTexCoords<WithColor<Point<S>, Color>, TexCoords<S>>;
+
+/// Simplified constructor for a **draw::mesh::Vertex**.
+pub fn new<S>(point: Point<S>, color: Color, tex_coords: TexCoords<S>) -> Vertex<S> {
+    WithTexCoords {
+        tex_coords,
+        vertex: WithColor {
+            color,
+            vertex: point,
+        },
+    }
+}
+
+/// Default texture coordinates, for the case where a type is not textured.
+pub fn default_tex_coords<S>() -> TexCoords<S>
+where
+    S: BaseFloat,
+{
+    Point2 {
+        x: S::zero(),
+        y: S::zero(),
+    }
+}
+
+impl<S> Vertex<S> {
+    /// Borrow the inner **Point**.
+    pub fn point(&self) -> &Point<S> {
+        &self.vertex.vertex
+    }
+
+    /// Mutably borrow the inner **Point**.
+    pub fn point_mut(&mut self) -> &mut Point<S> {
+        &mut self.vertex.vertex
+    }
+}
+
+/// A type that converts an iterator yielding colored points to an iterator yielding **Vertex**s.
+///
+/// Default values are used for tex_coords.
+#[derive(Clone, Debug)]
+pub struct IterFromColoredPoints<I, S = geom::DefaultScalar> {
+    colored_points: I,
+    _scalar: PhantomData<S>,
+}
+
+impl<I, S> IterFromColoredPoints<I, S> {
+    /// Produce an iterator that converts an iterator yielding colored points to an iterator
+    /// yielding **Vertex**s.
+    ///
+    /// The default value of `(0.0, 0.0)` is used for tex_coords.
+    pub fn new<P>(colored_points: P) -> Self
+    where
+        P: IntoIterator<IntoIter = I, Item = WithColor<Point<S>, Color>>,
+        I: Iterator<Item = WithColor<Point<S>, Color>>,
+    {
+        let colored_points = colored_points.into_iter();
+        let _scalar = PhantomData;
+        IterFromColoredPoints {
+            colored_points,
+            _scalar,
+        }
+    }
+}
+
+impl<I, S> Iterator for IterFromColoredPoints<I, S>
+where
+    I: Iterator<Item = WithColor<Point<S>, Color>>,
+    S: BaseFloat,
+{
+    type Item = Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.colored_points.next().map(|vertex| {
+            let tex_coords = default_tex_coords();
+            let vertex = WithTexCoords { tex_coords, vertex };
+            vertex
+        })
+    }
+}
+
+/// A type that converts an iterator yielding points to an iterator yielding **Vertex**s.
+///
+/// The given `default_color` is used to color every vertex.
+///
+/// The default value of `(0.0, 0.0)` is used for tex_coords.
+#[derive(Clone, Debug)]
+pub struct IterFromPoints<I, S = geom::DefaultScalar> {
+    points: I,
+    default_color: Color,
+    _scalar: PhantomData<S>,
+}
+
+impl<I, S> IterFromPoints<I, S> {
+    /// Produce an iterator that converts an iterator yielding points to an iterator yielding
+    /// **Vertex**s.
+    ///
+    /// The given `default_color` is used to color every vertex.
+    ///
+    /// The default value of `(0.0, 0.0)` is used for tex_coords.
+    pub fn new<P>(points: P, default_color: Color) -> Self
+    where
+        P: IntoIterator<IntoIter = I, Item = Point<S>>,
+        I: Iterator<Item = Point3<S>>,
+    {
+        let points = points.into_iter();
+        let _scalar = PhantomData;
+        IterFromPoints {
+            points,
+            default_color,
+            _scalar,
+        }
+    }
+}
+
+impl<I, S> Iterator for IterFromPoints<I, S>
+where
+    I: Iterator<Item = Point<S>>,
+    S: BaseFloat,
+{
+    type Item = Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.points.next().map(|vertex| {
+            let color = self.default_color;
+            let vertex = WithColor { vertex, color };
+            let tex_coords = default_tex_coords();
+            let vertex = WithTexCoords { vertex, tex_coords };
+            vertex
+        })
+    }
+}
+
+/// A type that converts an iterator yielding 2D points to an iterator yielding **Vertex**s.
+///
+/// The `z` position for each vertex will be `0.0`.
+///
+/// The given `default_color` is used to color every vertex.
+///
+/// The default value of `(0.0, 0.0)` is used for tex_coords.
+#[derive(Clone, Debug)]
+pub struct IterFromPoint2s<I, S = geom::DefaultScalar> {
+    points: I,
+    default_color: Color,
+    _scalar: PhantomData<S>,
+}
+
+impl<I, S> IterFromPoint2s<I, S> {
+    /// A type that converts an iterator yielding 2D points to an iterator yielding **Vertex**s.
+    ///
+    /// The `z` position for each vertex will be `0.0`.
+    ///
+    /// The given `default_color` is used to color every vertex.
+    ///
+    /// The default value of `(0.0, 0.0)` is used for tex_coords.
+    pub fn new<P>(points: P, default_color: Color) -> Self
+    where
+        P: IntoIterator<IntoIter = I, Item = Point2<S>>,
+        I: Iterator<Item = Point2<S>>,
+    {
+        let points = points.into_iter();
+        let _scalar = PhantomData;
+        IterFromPoint2s {
+            points,
+            default_color,
+            _scalar,
+        }
+    }
+}
+
+impl<I, S> Iterator for IterFromPoint2s<I, S>
+where
+    I: Iterator<Item = Point2<S>>,
+    S: BaseFloat,
+{
+    type Item = Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.points.next().map(|Point2 { x, y }| {
+            let vertex = Point3 { x, y, z: S::zero() };
+            let color = self.default_color;
+            let vertex = WithColor { vertex, color };
+            let tex_coords = default_tex_coords();
+            let vertex = WithTexCoords { vertex, tex_coords };
+            vertex
+        })
+    }
+}

--- a/src/draw/mod.rs
+++ b/src/draw/mod.rs
@@ -1,0 +1,693 @@
+use geom;
+use geom::graph::{edge, node};
+use math::{BaseFloat, Vector3};
+use std::cell::{Ref, RefCell};
+use std::collections::HashMap;
+use std::mem;
+use std::ops;
+
+use self::properties::spatial::position::{self, Position};
+use self::properties::{IntoDrawn, Primitive};
+pub use self::background::Background;
+pub use self::drawing::Drawing;
+pub use self::mesh::Mesh;
+pub use self::theme::Theme;
+
+pub mod backend;
+pub mod background;
+mod drawing;
+pub mod properties;
+pub mod mesh;
+pub mod theme;
+
+/// A simple API for drawing 2D and 3D graphics.
+///
+/// **Draw** provides a simple way to compose together geometric primitives and text (TODO) with
+/// custom colours and textures and draw them to the screen.
+///
+/// You can also ask **Draw** for the sequence of vertices or triangles (with or without
+/// colours/textures) that make up the entire scene that you have created.
+///
+/// Internally **Draw** uses a **geom::Graph** for placing geometry and text in 3D space.
+///
+/// **Draw** has 2 groups of methods:
+///
+/// 1. **Creation**: These methods compose new geometry and text with colours and textures.
+///
+/// 2. **Rendering**: These methods provide ways of rendering the graphics either directly to the
+///    frame for the current display or to a list of vertices or triangles for lower-level, more
+///    flexible access.
+#[derive(Clone, Debug)]
+pub struct Draw<S = geom::DefaultScalar>
+where
+    S: BaseFloat,
+{
+    // The state of the **Draw** behind a RefCell. We do this in order to avoid requiring a `mut`
+    // handle to a `draw`. The primary purpose of a **Draw** is to be an easy-as-possible,
+    // high-level API for drawing stuff. In order to be friendlier to new users, we want to avoid
+    // them having to think about mutability and focus on creativity. Rust-lang nuances can come
+    // later.
+    state: RefCell<State<S>>,
+}
+
+/// The inner state of the **Draw** type.
+///
+/// The **Draw** type stores its **State** behind a **RefCell** - a type used for moving mutability
+/// checks from compile time to runtime. We do this in order to avoid requiring a `mut` handle to a
+/// `draw`. The primary purpose of a **Draw** is to be an easy-as-possible, high-level API for
+/// drawing stuff. In order to be friendlier to new users, we want to avoid requiring them to think
+/// about mutability and instead focus on creativity. Rust-lang nuances can come later.
+#[derive(Clone, Debug)]
+pub struct State<S = geom::DefaultScalar>
+where
+    S: BaseFloat,
+{
+    /// Relative positioning, orientation and scaling of geometry.
+    geom_graph: geom::Graph<S>,
+    /// For performing a depth-first search over the geometry graph.
+    geom_graph_dfs: RefCell<geom::graph::node::Dfs<S>>,
+    /// The mesh containing vertices for all drawn shapes, etc.
+    mesh: Mesh<S>,
+    /// The map from node indices to their vertex and index ranges within the mesh.
+    ranges: HashMap<node::Index, Ranges>,
+    /// Primitives that are in the process of being drawn.
+    drawing: HashMap<node::Index, properties::Primitive<S>>,
+    /// The last node that was **Drawn**.
+    last_node_drawn: Option<node::Index>,
+    /// The theme containing default values.
+    theme: Theme,
+    /// If `Some`, the **Draw** should first clear the frame's gl context with the given color.
+    background_color: Option<properties::Rgba>,
+}
+
+/// The vertex and index ranges into a mesh for a particular node.
+#[derive(Clone, Debug)]
+struct Ranges {
+    vertices: ops::Range<usize>,
+    indices: ops::Range<usize>,
+}
+
+const WOULD_CYCLE: &'static str =
+    "drawing the given primitive with the given relative positioning would have caused a cycle \
+    within the geometry graph";
+
+/// An iterator yielding the transformed, indexed vertices for a node.
+pub type NodeVertices<'a, S> = node::TransformedVertices<::mesh::Vertices<Ref<'a, Mesh<S>>>, S>;
+
+// /// An iterator yielding the transformed vertices for a node.
+// pub struct NodeVertices<'a, S> {
+// }
+
+/// An iterator yielding the transformed raw vertices for a node.
+pub type RawNodeVertices<'a, S> = node::TransformedVertices<::mesh::RawVertices<Ref<'a, Mesh<S>>>, S>;
+
+/// An iterator yielding the transformed triangles for a node.
+pub type NodeTriangles<'a, S> = geom::tri::IterFromVertices<NodeVertices<'a, S>>;
+
+/// An iterator yielding all indexed mesh vertices transformed via the geometry graph.
+#[derive(Debug)]
+pub struct Vertices<'a, S>
+where
+    S: 'a + BaseFloat,
+{
+    draw: &'a Draw<S>,
+    node_vertices: Option<NodeVertices<'a, S>>,
+}
+
+/// An iterator yielding all indexed mesh triangles transformed via the geometry graph.
+pub type Triangles<'a, S> = geom::tri::IterFromVertices<Vertices<'a, S>>;
+
+/// An iterator yielding all raw mesh vertices transformed via the geometry graph.
+#[derive(Debug)]
+pub struct RawVertices<'a, S>
+where
+    S: 'a + BaseFloat,
+{
+    draw: &'a Draw<S>,
+    node_vertices: Option<RawNodeVertices<'a, S>>,
+}
+
+// Given some `position` along the given axis return the resulting geom::Graph edge and the parent.
+fn position_to_edge<S, F>(
+    node_index: node::Index,
+    position: &Position<S>,
+    draw: &mut State<S>,
+    axis: edge::Axis,
+    point_axis: &F,
+) -> (geom::graph::Edge<S>, node::Index)
+where
+    S: BaseFloat,
+    F: Fn(&mesh::vertex::Point<S>) -> S,
+{
+    match *position {
+        // *s* relative to *origin*.
+        Position::Absolute(s) => {
+            let edge = geom::graph::Edge::position(axis, s);
+            let origin = draw.geom_graph.origin();
+            (edge, origin)
+        }
+
+        Position::Relative(relative, maybe_parent) => {
+            let parent = maybe_parent
+                .or(draw.last_node_drawn)
+                .unwrap_or(draw.geom_graph.origin());
+            let edge = match relative {
+                // Relative position.
+                position::Relative::Scalar(s) => geom::graph::Edge::position(axis, s),
+
+                // Align end with
+                position::Relative::Align(align) => match align {
+                    position::Align::Middle => {
+                        let zero = S::zero();
+                        geom::graph::Edge::position(axis, zero)
+                    }
+                    align => {
+                        let one = S::one();
+                        let (direction, margin) = match align {
+                            position::Align::Start(mgn) => (-one, mgn.unwrap_or(S::zero())),
+                            position::Align::End(mgn) => (one, mgn.unwrap_or(S::zero())),
+                            _ => unreachable!(),
+                        };
+                        let node_dimension =
+                            draw.untransformed_dimension_of(&node_index, point_axis).unwrap();
+                        let parent_dimension = draw.dimension_of(&parent, point_axis)
+                            .expect("no node for relative position");
+                        let half = S::from(0.5).unwrap();
+                        let node_half_dim = node_dimension * half;
+                        let parent_half_dim = parent_dimension * half;
+                        let weight = direction * (parent_half_dim - node_half_dim - margin);
+                        geom::graph::Edge::position(axis, weight)
+                    }
+                },
+
+                position::Relative::Direction(direction, amt) => {
+                    let one = S::one();
+                    let direction = match direction {
+                        position::Direction::Backwards => -one,
+                        position::Direction::Forwards => one,
+                    };
+                    let node_dimension = draw.untransformed_dimension_of(&node_index, point_axis).unwrap();
+                    let parent_dimension = draw.dimension_of(&parent, point_axis)
+                        .expect("no node for relative position");
+                    let half = S::from(0.5).unwrap();
+                    let node_half_dim = node_dimension * half;
+                    let parent_half_dim = parent_dimension * half;
+                    let weight = direction * (parent_half_dim + node_half_dim + amt);
+                    geom::graph::Edge::position(axis, weight)
+                }
+            };
+            (edge, parent)
+        }
+    }
+}
+
+fn point_x<S: Clone>(p: &mesh::vertex::Point<S>) -> S {
+    p.x.clone()
+}
+fn point_y<S: Clone>(p: &mesh::vertex::Point<S>) -> S {
+    p.y.clone()
+}
+fn point_z<S: Clone>(p: &mesh::vertex::Point<S>) -> S {
+    p.z.clone()
+}
+
+// Convert the given `drawing` into its **Drawn** state and insert it into the mesh and geometry
+// graph.
+fn into_drawn<T, S>(
+    draw: &mut State<S>,
+    node_index: node::Index,
+    drawing: T,
+) -> Result<(), geom::graph::WouldCycle<S>>
+where
+    T: IntoDrawn<S>,
+    S: BaseFloat,
+{
+    // Convert the target into its **Drawn** state.
+    let (spatial, vertices, indices) = drawing.into_drawn(properties::Draw::new(draw));
+
+    // Update the mesh with the non-transformed vertices.
+    let vertices_start_index = draw.mesh.raw_vertex_count();
+    let indices_start_index = draw.mesh.indices().len();
+    let indices = indices.into_iter().map(|i| vertices_start_index + i);
+    draw.mesh.extend(vertices, indices);
+
+    // Update the **Draw**'s range map.
+    let vertices_end_index = draw.mesh.raw_vertex_count();
+    let indices_end_index = draw.mesh.indices().len();
+    let vertices = vertices_start_index..vertices_end_index;
+    let indices = indices_start_index..indices_end_index;
+    let ranges = Ranges { vertices, indices };
+    draw.ranges.insert(node_index, ranges);
+
+    // Update the edges within the geometry graph.
+    let p = &spatial.position;
+    let x = p.x
+        .map(|pos| (pos, edge::Axis::X, point_x as fn(&mesh::vertex::Point<S>) -> S));
+    let y = p.y.map(|pos| (pos, edge::Axis::Y, point_y as _));
+    let z = p.z.map(|pos| (pos, edge::Axis::Z, point_z as _));
+    let positions = x.into_iter().chain(y).chain(z);
+    for (position, axis, point_axis) in positions {
+        let (edge, parent) =
+            position_to_edge(node_index, &position, draw, axis, &point_axis);
+        draw.geom_graph.set_edge(parent, node_index, edge)?;
+    }
+
+    // Set this node as the last drawn node.
+    draw.last_node_drawn = Some(node_index);
+
+    Ok(())
+}
+
+// Convert the given `primitive` into its **Drawn** state and insert it into the mesh and geometry
+// graph.
+fn draw_primitive<S>(
+    draw: &mut State<S>,
+    node_index: node::Index,
+    primitive: Primitive<S>,
+) -> Result<(), geom::graph::WouldCycle<S>>
+where
+    S: BaseFloat,
+{
+    match primitive {
+        Primitive::Ellipse(ellipse) => {
+            into_drawn(draw, node_index, ellipse)
+        },
+    }
+}
+
+// Produce the min and max over the axis yielded via `point_axis` for the given `points`.
+fn min_max_dimension<I, F, S>(points: I, point_axis: &F) -> Option<(S, S)>
+where
+    I: IntoIterator<Item = mesh::vertex::Point<S>>,
+    F: Fn(&mesh::vertex::Point<S>) -> S,
+    S: BaseFloat,
+{
+    let mut points = points.into_iter();
+    points.next().map(|first| {
+        let s = point_axis(&first);
+        let init = (s, s);
+        points.fold(init, |(min, max), p| {
+            let s = point_axis(&p);
+            (s.min(min), s.max(max))
+        })
+    })
+}
+
+impl<S> State<S>
+where
+    S: BaseFloat,
+{
+    // Resets all state within the `Draw` instance.
+    fn reset(&mut self) {
+        self.geom_graph.clear();
+        self.geom_graph_dfs.borrow_mut().reset(&self.geom_graph);
+        self.drawing.clear();
+        self.ranges.clear();
+        self.mesh.clear();
+        self.background_color = None;
+    }
+
+    // // Produce the transformed mesh vertices for the node at the given index.
+    // //
+    // // Returns **None** if there is no node for the given index.
+    // fn node_vertices(&mut self, n: node::Index) -> Option<NodeVertices<S>> {
+
+    // }
+
+    // Drain any remaining `drawing`s, convert them to their **Drawn** state and insert them into
+    // the inner mesh and geometry graph.
+    fn finish_remaining_drawings(&mut self) -> Result<(), geom::graph::WouldCycle<S>> {
+        let mut drawing = mem::replace(&mut self.drawing, Default::default());
+        for (node_index, primitive) in drawing.drain() {
+            draw_primitive(self, node_index, primitive)?;
+        }
+        mem::replace(&mut self.drawing, drawing);
+        Ok(())
+    }
+
+    // Finish the drawing at the given node index if it is not yet complete.
+    fn finish_drawing(&mut self, n: &node::Index) -> Result<(), geom::graph::WouldCycle<S>> {
+        if let Some(primitive) = self.drawing.remove(n) {
+            draw_primitive(self, *n, primitive)?;
+        }
+        Ok(())
+    }
+
+    // The length of the untransformed node at the given index along the axis returned by the
+    // given `point_axis` function.
+    //
+    // **Note:** If this node's **Drawing** is not yet complete, this method will cause it to
+    // finish and submit the **Drawn** state to the inner geometry graph and mesh.
+    fn untransformed_dimension_of<F>(&mut self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&mesh::vertex::Point<S>) -> S,
+    {
+        self.finish_drawing(n).expect(WOULD_CYCLE);
+        self.ranges.get(n).and_then(|ranges| {
+            let points = self.mesh.points()[ranges.vertices.clone()].iter().cloned();
+            min_max_dimension(points, point_axis).map(|(min, max)| max - min)
+        })
+    }
+
+    // The length of the untransformed node at the given index along the *x* axis.
+    fn untransformed_x_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.untransformed_dimension_of(n, &point_x)
+    }
+
+    // The length of the untransformed node at the given index along the *y* axis.
+    fn untransformed_y_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.untransformed_dimension_of(n, &point_y)
+    }
+
+    // The length of the untransformed node at the given index along the *y* axis.
+    fn untransformed_z_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.untransformed_dimension_of(n, &point_z)
+    }
+
+    // The length of the transformed node at the given index along the axis returned by the given
+    // `point_axis` function.
+    //
+    // **Note:** If this node's **Drawing** is not yet complete, this method will cause it to
+    // finish and submit the **Drawn** state to the inner geometry graph and mesh.
+    fn dimension_of<F>(&mut self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&mesh::vertex::Point<S>) -> S,
+    {
+        self.finish_drawing(n).expect(WOULD_CYCLE);
+        self.ranges.get(n).and_then(|ranges| {
+            let points = self.mesh.points()[ranges.vertices.clone()].iter().cloned();
+            let points = self.geom_graph
+                .node_vertices(*n, points)
+                .expect("no node at index");
+            min_max_dimension(points, point_axis).map(|(min, max)| max - min)
+        })
+    }
+
+    // The length of the transformed node at the given index along the *x* axis.
+    fn x_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.dimension_of(n, &point_x)
+    }
+
+    // The length of the transformed node at the given index along the *y* axis.
+    fn y_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.dimension_of(n, &point_y)
+    }
+
+    // The length of the transformed node at the given index along the *z* axis.
+    fn z_dimension_of(&mut self, n: &node::Index) -> Option<S> {
+        self.dimension_of(n, &point_z)
+    }
+}
+
+impl<S> Draw<S>
+where
+    S: BaseFloat,
+{
+    /// Create a new **Draw** instance.
+    ///
+    /// This is the same as calling **Draw::default**.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resets all state within the `Draw` instance.
+    pub fn reset(&self) {
+        self.state.borrow_mut().reset();
+    }
+
+    // Primitive geometry.
+
+    /// Specify a color with which the background should be cleared.
+    pub fn background(&self) -> Background<S> {
+        background::new(self)
+    }
+
+    /// Add the given type to be drawn.
+    pub fn a<T>(&self, primitive: T) -> Drawing<T, S>
+    where
+        T: IntoDrawn<S> + Into<Primitive<S>>,
+        Primitive<S>: Into<Option<T>>,
+    {
+        let index = self.state.borrow_mut().geom_graph.add_node(geom::graph::Node::Point);
+        let primitive: Primitive<S> = primitive.into();
+        self.state.borrow_mut().drawing.insert(index, primitive);
+        drawing::new(self, index)
+    }
+
+    /// Begin drawing an **Ellipse**.
+    pub fn ellipse(&self) -> Drawing<properties::Ellipse<S>, S> {
+        self.a(Default::default())
+    }
+
+    // /// Draw a single **Tri** with the given points.
+    // pub fn tri(&mut self, a: Point3<S>, b: Point3<S>, c: Point3<S>) -> Drawing<S> {
+    //     let tri = geom::Tri([a, b, c]);
+    //     let node_id = self.geom_graph.add_node(tri);
+    //     unimplemented!()
+    // }
+
+    /// Produce the transformed mesh vertices for the node at the given index.
+    ///
+    /// Returns **None** if there is no node for the given index.
+    pub fn node_vertices(&self, n: node::Index) -> Option<NodeVertices<S>> {
+        self.state.borrow_mut().finish_drawing(&n).expect(WOULD_CYCLE);
+        let index_range = match self.state.borrow().ranges.get(&n) {
+            None => return None,
+            Some(ranges) => ranges.indices.clone(),
+        };
+        let vertices = ::mesh::vertices(self.mesh()).index_range(index_range);
+        self.state.borrow().geom_graph.node_vertices(n, vertices)
+    }
+
+    /// Produce the transformed triangles for the node at the given index.
+    ///
+    /// **Note:** If the node's **Drawing** was still in progress, it will first be finished and
+    /// inserted into the mesh and geometry graph before producing the triangles iterator.
+    pub fn node_triangles(&self, n: node::Index) -> Option<NodeTriangles<S>> {
+        self.node_vertices(n)
+            .map(geom::tri::iter_from_vertices)
+    }
+
+    /// Produce an iterator yielding all vertices from the inner mesh transformed via the inner
+    /// geometry graph.
+    ///
+    /// This method ignores the mesh indices buffer and instead produces the vertices "raw".
+    ///
+    /// **Note:** If there are any **Drawing**s in progress, these will first be drained and
+    /// completed before any vertices are yielded.
+    pub fn raw_vertices(&self) -> RawVertices<S> {
+        self.finish_remaining_drawings().expect(WOULD_CYCLE);
+        let state = self.state.borrow();
+        state.geom_graph_dfs.borrow_mut().reset(&state.geom_graph);
+        let draw = self;
+        let node_vertices = None;
+        RawVertices { draw, node_vertices }
+    }
+
+    /// Produce an iterator yielding all indexed vertices from the inner mesh transformed via the
+    /// inner geometry graph.
+    ///
+    /// Vertices are yielded in depth-first-order of the geometry graph nodes from which they are
+    /// produced.
+    ///
+    /// **Note:** If there are any **Drawing**s in progress, these will first be drained and
+    /// completed before any vertices are yielded.
+    pub fn vertices(&self) -> Vertices<S> {
+        self.finish_remaining_drawings().expect(WOULD_CYCLE);
+        let state = self.state.borrow();
+        state.geom_graph_dfs.borrow_mut().reset(&state.geom_graph);
+        let draw = self;
+        let node_vertices = None;
+        Vertices { draw, node_vertices }
+    }
+
+    /// Produce an iterator yielding all triangles from the inner mesh transformed via the inner
+    /// geometry graph.
+    ///
+    /// Triangles are yielded in depth-first-order of the geometry graph nodes from which they are
+    /// produced.
+    ///
+    /// **Note:** If there are any **Drawing**s in progress, these will first be drained and
+    /// completed before any vertices are yielded.
+    pub fn triangles(&self) -> Triangles<S> {
+        geom::tri::iter_from_vertices(self.vertices())
+    }
+
+    /// Borrow the **Draw**'s inner **Mesh**.
+    pub fn mesh(&self) -> Ref<Mesh<S>> {
+        Ref::map(self.state.borrow(), |s| &s.mesh)
+    }
+
+    // Dimensions methods.
+
+    /// The length of the untransformed node at the given index along the axis returned by the
+    /// given `point_axis` function.
+    pub fn untransformed_dimension_of<F>(&self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&mesh::vertex::Point<S>) -> S,
+    {
+        self.state.borrow_mut().untransformed_dimension_of(n, point_axis)
+    }
+
+    /// The length of the untransformed node at the given index along the *x* axis.
+    pub fn untransformed_x_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_x_dimension_of(n)
+    }
+
+    /// The length of the untransformed node at the given index along the *y* axis.
+    pub fn untransformed_y_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_y_dimension_of(n)
+    }
+
+    /// The length of the untransformed node at the given index along the *y* axis.
+    pub fn untransformed_z_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_z_dimension_of(n)
+    }
+
+    /// Determine the raw, untransformed dimensions of the node at the given index.
+    ///
+    /// Returns `None` if their is no node within the **geom::Graph** for the given index or if
+    /// the node has not yet been **Drawn**.
+    pub fn untransformed_dimensions_of(&self, n: &node::Index) -> Option<Vector3<S>> {
+        if self.state.borrow().geom_graph.node(*n).is_none()
+        || !self.state.borrow().ranges.contains_key(n) {
+            return None;
+        }
+        let dimensions = Vector3 {
+            x: self.untransformed_x_dimension_of(n).unwrap_or_else(S::zero),
+            y: self.untransformed_y_dimension_of(n).unwrap_or_else(S::zero),
+            z: self.untransformed_z_dimension_of(n).unwrap_or_else(S::zero),
+        };
+        Some(dimensions)
+    }
+
+    /// The length of the transformed node at the given index along the axis returned by the given
+    /// `point_axis` function.
+    pub fn dimension_of<F>(&self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&mesh::vertex::Point<S>) -> S,
+    {
+        self.state.borrow_mut().dimension_of(n, point_axis)
+    }
+
+    /// The length of the transformed node at the given index along the *x* axis.
+    pub fn x_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().x_dimension_of(n)
+    }
+
+    /// The length of the transformed node at the given index along the *y* axis.
+    pub fn y_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().y_dimension_of(n)
+    }
+
+    /// The length of the transformed node at the given index along the *z* axis.
+    pub fn z_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().z_dimension_of(n)
+    }
+
+    /// Drain any remaining `drawing`s, convert them to their **Drawn** state and insert them into
+    /// the inner mesh and geometry graph.
+    pub fn finish_remaining_drawings(&self) -> Result<(), geom::graph::WouldCycle<S>> {
+        self.state.borrow_mut().finish_remaining_drawings()
+    }
+}
+
+impl<S> Default for State<S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        let geom_graph = Default::default();
+        let geom_graph_dfs = RefCell::new(geom::graph::node::Dfs::new(&geom_graph));
+        let drawing = Default::default();
+        let mesh = Default::default();
+        let ranges = Default::default();
+        let theme = Default::default();
+        let last_node_drawn = Default::default();
+        let background_color = Default::default();
+        State {
+            geom_graph,
+            geom_graph_dfs,
+            mesh,
+            drawing,
+            ranges,
+            theme,
+            last_node_drawn,
+            background_color,
+        }
+    }
+}
+
+impl<S> Default for Draw<S>
+where
+    S: BaseFloat,
+{
+    fn default() -> Self {
+        let state = RefCell::new(Default::default());
+        Draw { state }
+    }
+}
+
+impl<'a, S> Iterator for Vertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = mesh::Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Vertices { ref draw, ref mut node_vertices } = *self;
+        loop {
+            if let Some(v) = node_vertices.as_mut().and_then(|n| n.next()) {
+                return Some(v);
+            }
+            let next_transform = {
+                let state = draw.state.borrow();
+                let mut dfs = state.geom_graph_dfs.borrow_mut();
+                dfs.next_transform(&state.geom_graph)
+            };
+            match next_transform {
+                None => return None,
+                Some((n, transform)) => {
+                    let index_range = match draw.state.borrow().ranges.get(&n) {
+                        None => continue,
+                        Some(ranges) => ranges.indices.clone(),
+                    };
+                    let vertices = ::mesh::vertices(draw.mesh()).index_range(index_range);
+                    let transformed_vertices = transform.vertices(vertices);
+                    *node_vertices = Some(transformed_vertices);
+                },
+            }
+        }
+    }
+}
+
+impl<'a, S> Iterator for RawVertices<'a, S>
+where
+    S: BaseFloat,
+{
+    type Item = mesh::Vertex<S>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let RawVertices { ref draw, ref mut node_vertices } = *self;
+        loop {
+            if let Some(v) = node_vertices.as_mut().and_then(|n| n.next()) {
+                return Some(v);
+            }
+            let next_transform = {
+                let state = draw.state.borrow();
+                let mut dfs = state.geom_graph_dfs.borrow_mut();
+                dfs.next_transform(&state.geom_graph)
+            };
+            match next_transform {
+                None => return None,
+                Some((n, transform)) => {
+                    let vertex_range = match draw.state.borrow().ranges.get(&n) {
+                        None => continue,
+                        Some(ranges) => ranges.vertices.clone(),
+                    };
+                    let vertices = ::mesh::raw_vertices(draw.mesh()).range(vertex_range);
+                    let transformed_vertices = transform.vertices(vertices);
+                    *node_vertices = Some(transformed_vertices);
+                },
+            }
+        }
+    }
+}

--- a/src/draw/properties/color.rs
+++ b/src/draw/properties/color.rs
@@ -1,0 +1,179 @@
+use color::{self, Alpha, IntoColor, Rgb, Rgba};
+use math::num_traits::{Float, One};
+
+/// The default scalar value for working with color channels, hues, etc.
+pub type DefaultScalar = f32;
+
+/// An **Rgba** type with the default Scalar.
+///
+/// Used by the **draw::properties::Common** type.
+pub type DefaultRgba = Rgba<DefaultScalar>;
+
+/// Types that may be converted directly into an RGBA color.
+pub trait IntoRgba<S>
+where
+    S: Float,
+{
+    /// Convert self into RGBA.
+    fn into_rgba(self) -> Rgba<S>;
+}
+
+/// Nodes that support setting colors.
+pub trait SetColor<S>: Sized
+where
+    S: Float,
+{
+    /// Provide a mutable reference to the RGBA field which can be used for setting colors.
+    fn rgba_mut(&mut self) -> &mut Option<Rgba<S>>;
+
+    /// Specify a color.
+    ///
+    /// This method supports any color type that can be converted into RGBA.
+    ///
+    /// Colors that have no alpha channel will be given an opaque alpha channel value `1.0`.
+    fn color<C>(mut self, color: C) -> Self
+    where
+        C: IntoRgba<S>,
+    {
+        *self.rgba_mut() = Some(color.into_rgba());
+        self
+    }
+
+    /// Specify the color via red, green and blue channels.
+    fn rgb(self, r: S, g: S, b: S) -> Self {
+        self.color(Rgb::new(r, g, b))
+    }
+
+    /// Specify the color via red, green, blue and alpha channels.
+    fn rgba(self, r: S, g: S, b: S, a: S) -> Self {
+        self.color(Rgba::new(r, g, b, a))
+    }
+
+    /// Specify the color via hue, saturation and luminance.
+    fn hsl<H>(self, h: H, s: S, l: S) -> Self
+    where
+        H: Into<color::RgbHue<S>>,
+    {
+        self.color(color::Hsl::new(h.into(), s, l))
+    }
+
+    /// Specify the color via hue, saturation, luminance and an alpha channel.
+    fn hsla<H>(self, h: H, s: S, l: S, a: S) -> Self
+    where
+        H: Into<color::RgbHue<S>>,
+    {
+        self.color(color::Hsla::new(h.into(), s, l, a))
+    }
+}
+
+impl<S> SetColor<S> for Option<Rgba<S>>
+where
+    S: Float,
+{
+    fn rgba_mut(&mut self) -> &mut Option<Rgba<S>> {
+        self
+    }
+}
+
+fn into_rgb_with_alpha<C, S>(color: C) -> Rgba<S>
+where
+    C: IntoColor<S>,
+    S: Float + One,
+{
+    let color = color.into_rgb();
+    let alpha = One::one();
+    Alpha { color, alpha }
+}
+
+impl<S> IntoRgba<S> for color::Xyz<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Yxy<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Lab<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Lch<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Rgb<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Hsl<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Hsv<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Hwb<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<S> IntoRgba<S> for color::Luma<S>
+where
+    S: Float + One,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        into_rgb_with_alpha(self)
+    }
+}
+
+impl<C, S> IntoRgba<S> for Alpha<C, S>
+where
+    C: IntoColor<S>,
+    S: Float,
+{
+    fn into_rgba(self) -> Rgba<S> {
+        let Alpha { color, alpha } = self;
+        let color = color.into_rgb();
+        Alpha { color, alpha }
+    }
+}

--- a/src/draw/properties/mod.rs
+++ b/src/draw/properties/mod.rs
@@ -1,0 +1,156 @@
+//! Parameters which a **Drawing** instance may use to describe certain properties of a drawing.
+//!
+//! Each time a new method is chained onto a **Drawing** instance, it uses the given values to set
+//! one or more properties for the drawing.
+//!
+//! Each **Drawing** instance is associated with a specific **Node** in the geometry graph and has
+//! a unique **node::Index** to simplify this.
+
+use draw;
+use geom::graph::node;
+use math::BaseFloat;
+use std::cell::RefCell;
+
+pub mod color;
+pub mod primitive;
+pub mod spatial;
+
+use self::spatial::dimension;
+
+pub use self::color::{IntoRgba, SetColor};
+pub use self::primitive::{Ellipse, Primitive};
+pub use self::spatial::dimension::SetDimensions;
+pub use self::spatial::position::SetPosition;
+
+/// The scalar type used for the color channel values.
+pub type ColorScalar = color::DefaultScalar;
+
+/// The RGBA type used by the `Common` params.
+pub type Rgba = color::DefaultRgba;
+
+// Methods for updating **Draw**'s geometry graph and mesh upon completion of **Drawing**.
+
+/// When a **Drawing** type is ready to be built it returns a **Drawn**.
+///
+/// **Drawn** is the information necessary to populate the parent **Draw** geometry graph and mesh.
+pub type Drawn<S, V, I> = (spatial::Properties<S>, V, I);
+
+/// A wrapper around the `draw::State` for the **IntoDrawn** trait implementations.
+#[derive(Debug)]
+pub struct Draw<'a, S>
+where
+    S: 'a + BaseFloat,
+{
+    state: RefCell<&'a mut draw::State<S>>,
+}
+
+impl<'a, S> Draw<'a, S>
+where
+    S: BaseFloat,
+{
+    /// Create a new **Draw**.
+    pub fn new(state: &'a mut draw::State<S>) -> Self {
+        Draw { state: RefCell::new(state) }
+    }
+
+    /// The length of the untransformed node at the given index along the axis returned by the
+    /// given `point_axis` function.
+    ///
+    /// **Note:** If this node's **Drawing** is not yet complete, this method will cause it to
+    /// finish and submit the **Drawn** state to the inner geometry graph and mesh.
+    pub fn untransformed_dimension_of<F>(&self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&draw::mesh::vertex::Point<S>) -> S,
+    {
+        self.state.borrow_mut().untransformed_dimension_of(n, point_axis)
+    }
+
+    /// The length of the untransformed node at the given index along the *x* axis.
+    pub fn untransformed_x_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_x_dimension_of(n)
+    }
+
+    /// The length of the untransformed node at the given index along the *y* axis.
+    pub fn untransformed_y_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_y_dimension_of(n)
+    }
+
+    /// The length of the untransformed node at the given index along the *y* axis.
+    pub fn untransformed_z_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().untransformed_z_dimension_of(n)
+    }
+
+    /// The length of the transformed node at the given index along the axis returned by the given
+    /// `point_axis` function.
+    ///
+    /// **Note:** If this node's **Drawing** is not yet complete, this method will cause it to
+    /// finish and submit the **Drawn** state to the inner geometry graph and mesh.
+    pub fn dimension_of<F>(&mut self, n: &node::Index, point_axis: &F) -> Option<S>
+    where
+        F: Fn(&draw::mesh::vertex::Point<S>) -> S,
+    {
+        self.state.borrow_mut().dimension_of(n, point_axis)
+    }
+
+    /// The length of the transformed node at the given index along the *x* axis.
+    pub fn x_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().x_dimension_of(n)
+    }
+
+    /// The length of the transformed node at the given index along the *y* axis.
+    pub fn y_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().y_dimension_of(n)
+    }
+
+    /// The length of the transformed node at the given index along the *z* axis.
+    pub fn z_dimension_of(&self, n: &node::Index) -> Option<S> {
+        self.state.borrow_mut().z_dimension_of(n)
+    }
+
+    /// Retrieve the given element from the inner **Theme**.
+    pub fn theme<F, T>(&self, get: F) -> T
+    where
+        F: FnOnce(&draw::Theme) -> T
+    {
+        let state = self.state.borrow();
+        get(&state.theme)
+    }
+}
+
+/// Types that can be **Drawn** into a parent **Draw** geometry graph and mesh.
+pub trait IntoDrawn<S>
+where
+    S: BaseFloat,
+{
+    /// The iterator type yielding all unique vertices in the drawing.
+    ///
+    /// The position of each yielded vertex should be relative to `0, 0, 0` as all displacement,
+    /// scaling and rotation transformations will be performed via the geometry graph.
+    type Vertices: IntoIterator<Item = draw::mesh::Vertex<S>>;
+    /// The iterator type yielding all vertex indices, describing edges of the drawing.
+    type Indices: IntoIterator<Item = usize>;
+    /// Consume `self` and return its **Drawn** form.
+    fn into_drawn(self, Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices>;
+}
+
+// Implement a method to simplify retrieving the dimensions of a type from `dimension::Properties`.
+
+impl<S> dimension::Properties<S>
+where
+    S: BaseFloat,
+{
+    /// Return the **Dimension**s as scalar values.
+    pub fn to_scalars(&self, draw: &Draw<S>) -> (Option<S>, Option<S>, Option<S>) {
+        const EXPECT_DIMENSION: &'static str = "no raw dimension for node";
+        let x = self.x
+            .as_ref()
+            .map(|x| x.to_scalar(|n| draw.untransformed_x_dimension_of(n).expect(EXPECT_DIMENSION)));
+        let y = self.y
+            .as_ref()
+            .map(|y| y.to_scalar(|n| draw.untransformed_y_dimension_of(n).expect(EXPECT_DIMENSION)));
+        let z = self.z
+            .as_ref()
+            .map(|z| z.to_scalar(|n| draw.untransformed_z_dimension_of(n).expect(EXPECT_DIMENSION)));
+        (x, y, z)
+    }
+}

--- a/src/draw/properties/primitive/ellipse.rs
+++ b/src/draw/properties/primitive/ellipse.rs
@@ -1,0 +1,120 @@
+use draw;
+use draw::properties::{spatial, ColorScalar, Draw, Drawn, IntoDrawn, Rgba, SetColor, SetDimensions, SetPosition};
+use draw::properties::spatial::{dimension, position};
+use geom;
+use math::{BaseFloat, Point2, Vector2};
+use std::ops;
+
+/// Properties related to drawing an **Ellipse**.
+#[derive(Clone, Debug)]
+pub struct Ellipse<S = geom::DefaultScalar> {
+    spatial: spatial::Properties<S>,
+    color: Option<Rgba>,
+    resolution: Option<usize>,
+}
+
+// Ellipse-specific methods.
+
+impl<S> Ellipse<S>
+where
+    S: BaseFloat,
+{
+    /// Specify the width and height of the **Ellipse** via a given **radius**.
+    pub fn radius(self, radius: S) -> Self {
+        let side = radius * (S::one() + S::one());
+        self.w_h(side, side)
+    }
+
+    /// The number of sides used to draw the ellipse.
+    pub fn resolution(mut self, resolution: usize) -> Self {
+        self.resolution = Some(resolution);
+        self
+    }
+}
+
+// Trait implementations.
+
+impl<S> IntoDrawn<S> for Ellipse<S>
+where
+    S: BaseFloat,
+{
+    type Vertices = draw::mesh::vertex::IterFromPoint2s<
+        geom::tri::VerticesFromIter<geom::ellipse::Triangles<S>, Point2<S>>,
+        S,
+    >;
+    type Indices = ops::Range<usize>;
+    fn into_drawn(self, draw: Draw<S>) -> Drawn<S, Self::Vertices, Self::Indices> {
+        let Ellipse {
+            spatial,
+            color,
+            resolution,
+        } = self;
+
+        // First get the dimensions of the ellipse.
+        let (maybe_x, maybe_y, maybe_z) = spatial.dimensions.to_scalars(&draw);
+        assert!(
+            maybe_z.is_none(),
+            "z dimension support for ellipse is unimplemented"
+        );
+
+        // TODO: These should probably be adjustable via Theme.
+        const DEFAULT_RESOLUTION: usize = 50;
+        let default_w = || S::from(100.0).unwrap();
+        let default_h = || S::from(100.0).unwrap();
+        let w = maybe_x.unwrap_or_else(default_w);
+        let h = maybe_y.unwrap_or_else(default_h);
+        let rect = geom::Rect::from_wh(Vector2 { x: w, y: h });
+        let resolution = resolution.unwrap_or(DEFAULT_RESOLUTION);
+        let color = color
+            .or_else(|| {
+                draw.theme(|theme| {
+                    theme
+                        .color
+                        .primitive
+                        .get(&draw::theme::Primitive::Ellipse)
+                        .map(|&c| c)
+                })
+            })
+            .unwrap_or(draw.theme(|t| t.color.default));
+
+        // TODO: Optimise this using the Circumference and ellipse indices iterators.
+        let tris = geom::Ellipse::new(rect, resolution).triangles();
+        let points = geom::tri::vertices_from_iter(tris);
+        let num_points = points.len();
+        let vertices = draw::mesh::vertex::IterFromPoint2s::new(points, color);
+        let indices = 0..num_points;
+
+        (spatial, vertices, indices)
+    }
+}
+
+impl<S> Default for Ellipse<S> {
+    fn default() -> Self {
+        let spatial = Default::default();
+        let color = Default::default();
+        let resolution = Default::default();
+        Ellipse {
+            spatial,
+            color,
+            resolution,
+        }
+    }
+}
+
+impl<S> SetPosition<S> for Ellipse<S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        SetPosition::properties(&mut self.spatial)
+    }
+}
+
+impl<S> SetDimensions<S> for Ellipse<S> {
+    fn properties(&mut self) -> &mut dimension::Properties<S> {
+        SetDimensions::properties(&mut self.spatial)
+    }
+}
+
+impl<S> SetColor<ColorScalar> for Ellipse<S> {
+    fn rgba_mut(&mut self) -> &mut Option<Rgba> {
+        SetColor::rgba_mut(&mut self.color)
+    }
+}

--- a/src/draw/properties/primitive/mod.rs
+++ b/src/draw/properties/primitive/mod.rs
@@ -1,0 +1,30 @@
+use geom;
+
+pub mod ellipse;
+
+pub use self::ellipse::Ellipse;
+
+/// A wrapper around all primitive sets of properties so that they may be stored within the
+/// **Draw**'s `drawing` field while they are being drawn.
+///
+/// This also allows us to flush all pending drawings to the mesh if `Draw::to_frame` is called
+/// before their respective **Drawing** types are dropped.
+#[derive(Clone, Debug)]
+pub enum Primitive<S = geom::DefaultScalar> {
+    Ellipse(Ellipse<S>),
+}
+
+impl<S> From<Ellipse<S>> for Primitive<S> {
+    fn from(prim: Ellipse<S>) -> Self {
+        Primitive::Ellipse(prim)
+    }
+}
+
+impl<S> Into<Option<Ellipse<S>>> for Primitive<S> {
+    fn into(self) -> Option<Ellipse<S>> {
+        match self {
+            Primitive::Ellipse(prim) => Some(prim),
+            //_ => None,
+        }
+    }
+}

--- a/src/draw/properties/spatial/dimension.rs
+++ b/src/draw/properties/spatial/dimension.rs
@@ -1,0 +1,271 @@
+use geom;
+use geom::graph::node;
+use math::{BaseFloat, Vector2, Vector3};
+
+/// Dimension properties for **Drawing** a **Node**.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Properties<S = geom::DefaultScalar> {
+    /// Dimension over the *x* axis.
+    pub x: Option<Dimension<S>>,
+    /// Dimension over the *y* axis.
+    pub y: Option<Dimension<S>>,
+    /// Dimension over the *z* axis.
+    pub z: Option<Dimension<S>>,
+}
+
+/// The length of a **Node** over either the *x* or *y* axes.
+///
+/// This type is used to represent the different ways in which a dimension may be sized.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Dimension<S = geom::DefaultScalar> {
+    /// Some specific length has been given.
+    Absolute(S),
+    /// The dimension is described as relative to the node at the given index.
+    Relative(node::Index, Relative<S>),
+}
+
+/// Describes a dimension that is relative to some other node.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Relative<S = geom::DefaultScalar> {
+    /// Match the exact dimension of the other node.
+    Matching,
+    /// Match the dimension but pad it with the given Scalar.
+    Padded(S),
+    /// Multiply the dimension of the other relative node's dimension.
+    Scaled(S),
+}
+
+/// Nodes that support different dimensions.
+pub trait SetDimensions<S>: Sized {
+    /// Provide a mutable reference to the **dimension::Properties** for updating.
+    fn properties(&mut self) -> &mut Properties<S>;
+
+    // Setters for each axis.
+
+    /// Set the length along the x axis.
+    fn x_dimension(mut self, x: Dimension<S>) -> Self {
+        self.properties().x = Some(x);
+        self
+    }
+
+    /// Set the length along the y axis.
+    fn y_dimension(mut self, y: Dimension<S>) -> Self {
+        self.properties().y = Some(y);
+        self
+    }
+
+    /// Set the length along the z axis.
+    fn z_dimension(mut self, z: Dimension<S>) -> Self {
+        self.properties().z = Some(z);
+        self
+    }
+
+    // Absolute dimensions.
+
+    /// Set the absolute width for the node.
+    fn width(self, w: S) -> Self {
+        self.x_dimension(Dimension::Absolute(w))
+    }
+
+    /// Set the absolute height for the node.
+    fn height(self, h: S) -> Self {
+        self.y_dimension(Dimension::Absolute(h))
+    }
+
+    /// Set the absolute depth for the node.
+    fn depth(self, d: S) -> Self {
+        self.z_dimension(Dimension::Absolute(d))
+    }
+
+    /// Short-hand for the **width** method.
+    fn w(self, w: S) -> Self {
+        self.width(w)
+    }
+
+    /// Short-hand for the **height** method.
+    fn h(self, h: S) -> Self {
+        self.height(h)
+    }
+
+    /// Short-hand for the **depth** method.
+    fn d(self, d: S) -> Self {
+        self.depth(d)
+    }
+
+    /// Set the **x** and **y** dimensions for the node.
+    fn wh(self, v: Vector2<S>) -> Self {
+        self.w(v.x).h(v.y)
+    }
+
+    /// Set the **x**, **y** and **z** dimensions for the node.
+    fn whd(self, v: Vector3<S>) -> Self {
+        self.w(v.x).h(v.y).d(v.z)
+    }
+
+    /// Set the width and height for the node.
+    fn w_h(self, x: S, y: S) -> Self {
+        self.wh(Vector2 { x, y })
+    }
+
+    /// Set the width and height for the node.
+    fn w_h_d(self, x: S, y: S, z: S) -> Self {
+        self.whd(Vector3 { x, y, z })
+    }
+
+    // Relative dimensions.
+
+    /// Some relative dimension along the **x** axis.
+    fn x_dimension_relative(self, other: node::Index, x: Relative<S>) -> Self {
+        self.x_dimension(Dimension::Relative(other, x))
+    }
+
+    /// Some relative dimension along the **y** axis.
+    fn y_dimension_relative(self, other: node::Index, y: Relative<S>) -> Self {
+        self.y_dimension(Dimension::Relative(other, y))
+    }
+
+    /// Some relative dimension along the **z** axis.
+    fn z_dimension_relative(self, other: node::Index, z: Relative<S>) -> Self {
+        self.z_dimension(Dimension::Relative(other, z))
+    }
+
+    /// Set the x-axis dimension as the width of the node at the given index.
+    fn w_of(self, other: node::Index) -> Self {
+        self.x_dimension_relative(other, Relative::Matching)
+    }
+
+    /// Set the y-axis dimension as the height of the node at the given index.
+    fn h_of(self, other: node::Index) -> Self {
+        self.y_dimension_relative(other, Relative::Matching)
+    }
+
+    /// Set the z-axis dimension as the depth of the node at the given index.
+    fn d_of(self, other: node::Index) -> Self {
+        self.z_dimension_relative(other, Relative::Matching)
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index.
+    fn wh_of(self, other: node::Index) -> Self {
+        self.w_of(other).h_of(other)
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index.
+    fn whd_of(self, other: node::Index) -> Self {
+        self.w_of(other).h_of(other).d_of(other)
+    }
+
+    /// Set the width as the width of the node at the given index padded at both ends by the
+    /// given Scalar.
+    fn padded_w_of(self, other: node::Index, pad: S) -> Self {
+        self.x_dimension_relative(other, Relative::Padded(pad))
+    }
+
+    /// Set the height as the height of the node at the given index padded at both ends by the
+    /// given Scalar.
+    fn padded_h_of(self, other: node::Index, pad: S) -> Self {
+        self.y_dimension_relative(other, Relative::Padded(pad))
+    }
+
+    /// Set the depth as the depth of the node at the given index padded at both ends by the
+    /// given Scalar.
+    fn padded_d_of(self, other: node::Index, pad: S) -> Self {
+        self.z_dimension_relative(other, Relative::Padded(pad))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index with each dimension
+    /// padded by the given scalar.
+    fn padded_wh_of(self, other: node::Index, pad: S) -> Self
+    where
+        S: Clone,
+    {
+        self.padded_w_of(other, pad.clone()).padded_h_of(other, pad)
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index with each dimension
+    /// padded by the given scalar.
+    fn padded_whd_of(self, other: node::Index, pad: S) -> Self
+    where
+        S: Clone,
+    {
+        self.padded_w_of(other, pad.clone())
+            .padded_h_of(other, pad.clone())
+            .padded_d_of(other, pad)
+    }
+
+    /// Set the width as the width of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    fn scaled_w_of(self, other: node::Index, scale: S) -> Self {
+        self.x_dimension_relative(other, Relative::Scaled(scale))
+    }
+
+    /// Set the height as the height of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    fn scaled_h_of(self, other: node::Index, scale: S) -> Self {
+        self.y_dimension_relative(other, Relative::Scaled(scale))
+    }
+
+    /// Set the depth as the depth of the node at the given index multiplied by the given **scale**
+    /// Scalar value.
+    fn scaled_d_of(self, other: node::Index, scale: S) -> Self {
+        self.z_dimension_relative(other, Relative::Scaled(scale))
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index multiplied by the given
+    /// **scale** Scalar value.
+    fn scaled_wh_of(self, other: node::Index, scale: S) -> Self
+    where
+        S: Clone,
+    {
+        self.scaled_w_of(other, scale.clone())
+            .scaled_h_of(other, scale)
+    }
+
+    /// Set the dimensions as the dimensions of the node at the given index multiplied by the given
+    /// **scale** Scalar value.
+    fn scaled_whd_of(self, other: node::Index, scale: S) -> Self
+    where
+        S: Clone,
+    {
+        self.scaled_w_of(other, scale.clone())
+            .scaled_h_of(other, scale.clone())
+            .scaled_d_of(other, scale)
+    }
+}
+
+impl<S> SetDimensions<S> for Properties<S> {
+    fn properties(&mut self) -> &mut Properties<S> {
+        self
+    }
+}
+
+impl<S> Default for Properties<S> {
+    fn default() -> Self {
+        let x = None;
+        let y = None;
+        let z = None;
+        Properties { x, y, z }
+    }
+}
+
+impl<S> Dimension<S>
+where
+    S: BaseFloat,
+{
+    /// Return the **Dimension** as a scalar value.
+    ///
+    /// Relative dimensions are produced by accessing the dimension of some relative node via the
+    /// given `dimension_of` function.
+    pub fn to_scalar<F>(&self, dimension_of: F) -> S
+    where
+        F: FnOnce(&node::Index) -> S,
+    {
+        match *self {
+            Dimension::Absolute(s) => s,
+            Dimension::Relative(ref n, relative) => match relative {
+                Relative::Matching => dimension_of(n),
+                Relative::Padded(pad) => dimension_of(n) - pad * (S::one() + S::one()),
+                Relative::Scaled(scale) => dimension_of(n) * scale,
+            },
+        }
+    }
+}

--- a/src/draw/properties/spatial/mod.rs
+++ b/src/draw/properties/spatial/mod.rs
@@ -1,0 +1,49 @@
+use geom;
+
+pub mod dimension;
+pub mod position;
+// pub mod orientation;
+
+pub use self::dimension::SetDimensions;
+pub use self::position::SetPosition;
+// pub use self::orientation::SetOrientation;
+
+/// Types that may be positioned, sized and oriented within 3D space.
+pub trait SetSpatial<S>: SetDimensions<S> + SetPosition<S> {}
+
+impl<S, T> SetSpatial<S> for T
+where
+    T: SetDimensions<S> + SetPosition<S>,
+{
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Properties<S = geom::DefaultScalar> {
+    pub position: position::Properties<S>,
+    pub dimensions: dimension::Properties<S>,
+    // pub orientation: orientation::Properties<S>,
+}
+
+impl<S> Default for Properties<S> {
+    fn default() -> Self {
+        let position = Default::default();
+        let dimensions = Default::default();
+        //let orientation = Default::default();
+        Properties {
+            position,
+            dimensions,
+        }
+    }
+}
+
+impl<S> SetPosition<S> for Properties<S> {
+    fn properties(&mut self) -> &mut position::Properties<S> {
+        self.position.properties()
+    }
+}
+
+impl<S> SetDimensions<S> for Properties<S> {
+    fn properties(&mut self) -> &mut dimension::Properties<S> {
+        self.dimensions.properties()
+    }
+}

--- a/src/draw/properties/spatial/position.rs
+++ b/src/draw/properties/spatial/position.rs
@@ -1,0 +1,645 @@
+//! Items related to describing positioning along each axis as
+
+use geom;
+use geom::graph::node;
+use math::{Point2, Point3};
+
+/// Position properties for **Drawing** a **Node**.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Properties<S = geom::DefaultScalar> {
+    /// Position along the *x* axis.
+    pub x: Option<Position<S>>,
+    /// Position along the *y* axis.
+    pub y: Option<Position<S>>,
+    /// Position along the *z* axis.
+    pub z: Option<Position<S>>,
+}
+
+/// A **Position** along a single axis.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Position<S = geom::DefaultScalar> {
+    /// A specific position.
+    Absolute(S),
+    /// A position relative to some other Node.
+    Relative(Relative<S>, Option<node::Index>),
+}
+
+/// Positions that are described as **Relative** to some other **Node**.
+///
+/// **Relative** describes a relative position along a single axis.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Relative<S = geom::DefaultScalar> {
+    /// A relative scalar distance.
+    Scalar(S),
+    /// Aligned to either the `Start`, `Middle` or `End`.
+    Align(Align<S>),
+    /// A distance as a `Scalar` value over the given `Direction`.
+    Direction(Direction, S),
+}
+
+/// Directionally positioned, normally relative to some other node.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Direction {
+    /// Positioned forwards (*positive* **Scalar**) along some **Axis**.
+    Forwards,
+    /// Positioned backwards (*negative* **Scalar**) along some **Axis**.
+    Backwards,
+}
+
+/// The orientation of **Align**ment along some **Axis**.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Align<S> {
+    /// **Align** our **Start** with the **Start** of some other node along the **Axis** with the
+    /// given margin.
+    Start(Option<S>),
+    /// **Align** our **Middle** with the **Middle** of some other node along the **Axis**.
+    Middle,
+    /// **Align** our **End** with the **End** of some other node along the **Axis** with the given
+    /// margin.
+    End(Option<S>),
+}
+
+/// An API for setting the **position::Properties**.
+pub trait SetPosition<S>: Sized {
+    /// Provide a mutable reference to the **position::Properties** for updating.
+    fn properties(&mut self) -> &mut Properties<S>;
+
+    // Setters for each axis.
+
+    /// Build with the given **Position** along the *x* axis.
+    fn x_position(mut self, position: Position<S>) -> Self {
+        self.properties().x = Some(position);
+        self
+    }
+
+    /// Build with the given **Position** along the *y* axis.
+    fn y_position(mut self, position: Position<S>) -> Self {
+        self.properties().y = Some(position);
+        self
+    }
+
+    /// Build with the given **Position** along the *z* axis.
+    fn z_position(mut self, position: Position<S>) -> Self {
+        self.properties().z = Some(position);
+        self
+    }
+
+    // Absolute positioning.
+
+    /// Build with the given **Absolute** **Position** along the *x* axis.
+    fn x(self, x: S) -> Self {
+        self.x_position(Position::Absolute(x))
+    }
+
+    /// Build with the given **Absolute** **Position** along the *y* axis.
+    fn y(self, y: S) -> Self {
+        self.y_position(Position::Absolute(y))
+    }
+
+    /// Build with the given **Absolute** **Position** along the *z* axis.
+    fn z(self, y: S) -> Self {
+        self.z_position(Position::Absolute(y))
+    }
+
+    /// Set the **Position** with some two-dimensional point.
+    fn xy(self, p: Point2<S>) -> Self {
+        self.x(p.x).y(p.y)
+    }
+
+    /// Set the **Position** with some three-dimensional point.
+    fn xyz(self, p: Point3<S>) -> Self {
+        self.x(p.x).y(p.y).z(p.z)
+    }
+
+    /// Set the **Position** with *x* *y* coordinates.
+    fn x_y(self, x: S, y: S) -> Self {
+        self.xy(Point2 { x, y })
+    }
+
+    /// Set the **Position** with *x* *y* *z* coordinates.
+    fn x_y_z(self, x: S, y: S, z: S) -> Self {
+        self.xyz(Point3 { x, y, z })
+    }
+
+    // Relative positioning.
+
+    /// Set the *x* **Position** **Relative** to the previous node.
+    fn x_position_relative(self, x: Relative<S>) -> Self {
+        self.x_position(Position::Relative(x, None))
+    }
+
+    /// Set the *y* **Position** **Relative** to the previous node.
+    fn y_position_relative(self, y: Relative<S>) -> Self {
+        self.y_position(Position::Relative(y, None))
+    }
+
+    /// Set the *z* **Position** **Relative** to the previous node.
+    fn z_position_relative(self, z: Relative<S>) -> Self {
+        self.z_position(Position::Relative(z, None))
+    }
+
+    /// Set the *x* and *y* **Position**s **Relative** to the previous node.
+    fn x_y_position_relative(self, x: Relative<S>, y: Relative<S>) -> Self {
+        self.x_position_relative(x).y_position_relative(y)
+    }
+
+    /// Set the *x*, *y* and *z* **Position**s **Relative** to the previous node.
+    fn x_y_z_position_relative(self, x: Relative<S>, y: Relative<S>, z: Relative<S>) -> Self {
+        self.x_y_position_relative(x, y).z_position_relative(z)
+    }
+
+    /// Set the *x* **Position** **Relative** to the given node.
+    fn x_position_relative_to(self, other: node::Index, x: Relative<S>) -> Self {
+        self.x_position(Position::Relative(x, Some(other)))
+    }
+
+    /// Set the *y* **Position** **Relative** to the given node.
+    fn y_position_relative_to(self, other: node::Index, y: Relative<S>) -> Self {
+        self.y_position(Position::Relative(y, Some(other)))
+    }
+
+    /// Set the *y* **Position** **Relative** to the given node.
+    fn z_position_relative_to(self, other: node::Index, z: Relative<S>) -> Self {
+        self.z_position(Position::Relative(z, Some(other)))
+    }
+
+    /// Set the *x* and *y* **Position**s **Relative** to the given node.
+    fn x_y_position_relative_to(self, other: node::Index, x: Relative<S>, y: Relative<S>) -> Self {
+        self.x_position_relative_to(other, x)
+            .y_position_relative_to(other, y)
+    }
+
+    /// Set the *x*, *y* and *z* **Position**s **Relative** to the given node.
+    fn x_y_z_position_relative_to(
+        self,
+        other: node::Index,
+        x: Relative<S>,
+        y: Relative<S>,
+        z: Relative<S>,
+    ) -> Self {
+        self.x_y_position_relative_to(other, x, y)
+            .z_position_relative_to(other, z)
+    }
+
+    // Relative `Scalar` positioning.
+
+    /// Set the **Position** as a **Scalar** along the *x* axis **Relative** to the middle of
+    /// previous node.
+    fn x_relative(self, x: S) -> Self {
+        self.x_position_relative(Relative::Scalar(x))
+    }
+
+    /// Set the **Position** as a **Scalar** along the *y* axis **Relative** to the middle of
+    /// previous node.
+    fn y_relative(self, y: S) -> Self {
+        self.y_position_relative(Relative::Scalar(y))
+    }
+
+    /// Set the **Position** as a **Scalar** along the *z* axis **Relative** to the middle of
+    /// previous node.
+    fn z_relative(self, z: S) -> Self {
+        self.z_position_relative(Relative::Scalar(z))
+    }
+
+    /// Set the **Position** as a **Point** **Relative** to the middle of the previous node.
+    fn xy_relative(self, p: Point2<S>) -> Self {
+        self.x_relative(p.x).y_relative(p.y)
+    }
+
+    /// Set the **Position** as a **Point** **Relative** to the middle of the previous node.
+    fn xyz_relative(self, p: Point3<S>) -> Self {
+        self.x_relative(p.x).y_relative(p.y).z_relative(p.z)
+    }
+
+    /// Set the **Position** as **Scalar**s along the *x* and *y* axes **Relative** to the middle
+    /// of the previous node.
+    fn x_y_relative(self, x: S, y: S) -> Self {
+        self.xy_relative(Point2 { x, y })
+    }
+
+    /// Set the **Position** as **Scalar**s along the *x*, *y* and *z* axes **Relative** to the
+    /// middle of the previous node.
+    fn x_y_z_relative(self, x: S, y: S, z: S) -> Self {
+        self.xyz_relative(Point3 { x, y, z })
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn x_relative_to(self, other: node::Index, x: S) -> Self {
+        self.x_position_relative_to(other, Relative::Scalar(x))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn y_relative_to(self, other: node::Index, y: S) -> Self {
+        self.y_position_relative_to(other, Relative::Scalar(y))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn z_relative_to(self, other: node::Index, z: S) -> Self {
+        self.z_position_relative_to(other, Relative::Scalar(z))
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn xy_relative_to(self, other: node::Index, p: Point2<S>) -> Self {
+        self.x_relative_to(other, p.x).y_relative_to(other, p.y)
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn xyz_relative_to(self, other: node::Index, p: Point3<S>) -> Self {
+        self.x_relative_to(other, p.x)
+            .y_relative_to(other, p.y)
+            .z_relative_to(other, p.z)
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn x_y_relative_to(self, other: node::Index, x: S, y: S) -> Self {
+        self.xy_relative_to(other, Point2 { x, y })
+    }
+
+    /// Set the position relative to the node with the given node::Index.
+    fn x_y_z_relative_to(self, other: node::Index, x: S, y: S, z: S) -> Self {
+        self.xyz_relative_to(other, Point3 { x, y, z })
+    }
+
+    // Directional positioning.
+
+    /// Build with the **Position** along the *x* axis as some distance from another node.
+    fn x_direction(self, direction: Direction, x: S) -> Self {
+        self.x_position_relative(Relative::Direction(direction, x))
+    }
+
+    /// Build with the **Position** along the *y* axis as some distance from another node.
+    fn y_direction(self, direction: Direction, y: S) -> Self {
+        self.y_position_relative(Relative::Direction(direction, y))
+    }
+
+    /// Build with the **Position** along the *z* axis as some distance from another node.
+    fn z_direction(self, direction: Direction, z: S) -> Self {
+        self.z_position_relative(Relative::Direction(direction, z))
+    }
+
+    /// Build with the **Position** as some distance to the left of another node.
+    fn left(self, x: S) -> Self {
+        self.x_direction(Direction::Backwards, x)
+    }
+
+    /// Build with the **Position** as some distance to the right of another node.
+    fn right(self, x: S) -> Self {
+        self.x_direction(Direction::Forwards, x)
+    }
+
+    /// Build with the **Position** as some distance below another node.
+    fn down(self, y: S) -> Self {
+        self.y_direction(Direction::Backwards, y)
+    }
+
+    /// Build with the **Position** as some distance above another node.
+    fn up(self, y: S) -> Self {
+        self.y_direction(Direction::Forwards, y)
+    }
+
+    /// Build with the **Position** as some distance in front of another node.
+    fn backwards(self, z: S) -> Self {
+        self.z_direction(Direction::Backwards, z)
+    }
+
+    /// Build with the **Position** as some distance behind another node.
+    fn forwards(self, z: S) -> Self {
+        self.z_direction(Direction::Forwards, z)
+    }
+
+    /// Build with the **Position** along the *x* axis as some distance from the given node.
+    fn x_direction_from(self, other: node::Index, direction: Direction, x: S) -> Self {
+        self.x_position_relative_to(other, Relative::Direction(direction, x))
+    }
+
+    /// Build with the **Position** along the *y* axis as some distance from the given node.
+    fn y_direction_from(self, other: node::Index, direction: Direction, y: S) -> Self {
+        self.y_position_relative_to(other, Relative::Direction(direction, y))
+    }
+
+    /// Build with the **Position** along the *z* axis as some distance from the given node.
+    fn z_direction_from(self, other: node::Index, direction: Direction, z: S) -> Self {
+        self.z_position_relative_to(other, Relative::Direction(direction, z))
+    }
+
+    /// Build with the **Position** as some distance to the left of the given node.
+    fn left_from(self, other: node::Index, x: S) -> Self {
+        self.x_direction_from(other, Direction::Backwards, x)
+    }
+
+    /// Build with the **Position** as some distance to the right of the given node.
+    fn right_from(self, other: node::Index, x: S) -> Self {
+        self.x_direction_from(other, Direction::Forwards, x)
+    }
+
+    /// Build with the **Position** as some distance below the given node.
+    fn down_from(self, other: node::Index, y: S) -> Self {
+        self.y_direction_from(other, Direction::Backwards, y)
+    }
+
+    /// Build with the **Position** as some distance above the given node.
+    fn up_from(self, other: node::Index, y: S) -> Self {
+        self.y_direction_from(other, Direction::Forwards, y)
+    }
+
+    /// Build with the **Position** as some distance in front of the given node.
+    fn backwards_from(self, other: node::Index, z: S) -> Self {
+        self.z_direction_from(other, Direction::Backwards, z)
+    }
+
+    /// Build with the **Position** as some distance above the given node.
+    fn forwards_from(self, other: node::Index, z: S) -> Self {
+        self.z_direction_from(other, Direction::Forwards, z)
+    }
+
+    // Alignment positioning.
+
+    /// Align the **Position** of the node along the *x* axis.
+    fn x_align(self, align: Align<S>) -> Self {
+        self.x_position_relative(Relative::Align(align))
+    }
+
+    /// Align the **Position** of the node along the *y* axis.
+    fn y_align(self, align: Align<S>) -> Self {
+        self.y_position_relative(Relative::Align(align))
+    }
+
+    /// Align the **Position** of the node along the *z* axis.
+    fn z_align(self, align: Align<S>) -> Self {
+        self.z_position_relative(Relative::Align(align))
+    }
+
+    /// Align the position to the left.
+    fn align_left(self) -> Self {
+        self.x_align(Align::Start(None))
+    }
+
+    /// Align the position to the left.
+    fn align_left_with_margin(self, margin: S) -> Self {
+        self.x_align(Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_x(self) -> Self {
+        self.x_align(Align::Middle)
+    }
+
+    /// Align the position to the right.
+    fn align_right(self) -> Self {
+        self.x_align(Align::End(None))
+    }
+
+    /// Align the position to the right.
+    fn align_right_with_margin(self, margin: S) -> Self {
+        self.x_align(Align::End(Some(margin)))
+    }
+
+    /// Align the position to the bottom.
+    fn align_bottom(self) -> Self {
+        self.y_align(Align::Start(None))
+    }
+
+    /// Align the position to the bottom.
+    fn align_bottom_with_margin(self, margin: S) -> Self {
+        self.y_align(Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_y(self) -> Self {
+        self.y_align(Align::Middle)
+    }
+
+    /// Align the position to the top.
+    fn align_top(self) -> Self {
+        self.y_align(Align::End(None))
+    }
+
+    /// Align the position to the top.
+    fn align_top_with_margin(self, margin: S) -> Self {
+        self.y_align(Align::End(Some(margin)))
+    }
+
+    /// Align the position to the front.
+    fn align_front(self) -> Self {
+        self.z_align(Align::Start(None))
+    }
+
+    /// Align the position to the front.
+    fn align_front_with_margin(self, margin: S) -> Self {
+        self.z_align(Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_z(self) -> Self {
+        self.z_align(Align::Middle)
+    }
+
+    /// Align the position to the back.
+    fn align_back(self) -> Self {
+        self.z_align(Align::End(None))
+    }
+
+    /// Align the position to the back.
+    fn align_back_with_margin(self, margin: S) -> Self {
+        self.z_align(Align::End(Some(margin)))
+    }
+
+    /// Align the **Position** of the node with the given node along the *x* axis.
+    fn x_align_to(self, other: node::Index, align: Align<S>) -> Self {
+        self.x_position_relative_to(other, Relative::Align(align))
+    }
+
+    /// Align the **Position** of the node with the given node along the *y* axis.
+    fn y_align_to(self, other: node::Index, align: Align<S>) -> Self {
+        self.y_position_relative_to(other, Relative::Align(align))
+    }
+
+    /// Align the **Position** of the node with the given node along the *z* axis.
+    fn z_align_to(self, other: node::Index, align: Align<S>) -> Self {
+        self.z_position_relative_to(other, Relative::Align(align))
+    }
+
+    /// Align the position to the left.
+    fn align_left_of(self, other: node::Index) -> Self {
+        self.x_align_to(other, Align::Start(None))
+    }
+
+    /// Align the position to the left.
+    fn align_left_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.x_align_to(other, Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_x_of(self, other: node::Index) -> Self {
+        self.x_align_to(other, Align::Middle)
+    }
+
+    /// Align the position to the right.
+    fn align_right_of(self, other: node::Index) -> Self {
+        self.x_align_to(other, Align::End(None))
+    }
+
+    /// Align the position to the right.
+    fn align_right_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.x_align_to(other, Align::End(Some(margin)))
+    }
+
+    /// Align the position to the bottom.
+    fn align_bottom_of(self, other: node::Index) -> Self {
+        self.y_align_to(other, Align::Start(None))
+    }
+
+    /// Align the position to the bottom.
+    fn align_bottom_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.y_align_to(other, Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_y_of(self, other: node::Index) -> Self {
+        self.y_align_to(other, Align::Middle)
+    }
+
+    /// Align the position to the top.
+    fn align_top_of(self, other: node::Index) -> Self {
+        self.y_align_to(other, Align::End(None))
+    }
+
+    /// Align the position to the top.
+    fn align_top_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.y_align_to(other, Align::End(Some(margin)))
+    }
+
+    /// Align the position to the front.
+    fn align_front_of(self, other: node::Index) -> Self {
+        self.z_align_to(other, Align::Start(None))
+    }
+
+    /// Align the position to the front.
+    fn align_front_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.z_align_to(other, Align::Start(Some(margin)))
+    }
+
+    /// Align the position to the middle.
+    fn align_middle_z_of(self, other: node::Index) -> Self {
+        self.z_align_to(other, Align::Middle)
+    }
+
+    /// Align the position to the back.
+    fn align_back_of(self, other: node::Index) -> Self {
+        self.z_align_to(other, Align::End(None))
+    }
+
+    /// Align the position to the back.
+    fn align_back_of_with_margin(self, other: node::Index, margin: S) -> Self {
+        self.z_align_to(other, Align::End(Some(margin)))
+    }
+
+    // Alignment combinations.
+
+    /// Align the node to the middle of the last node.
+    fn middle(self) -> Self {
+        self.align_middle_x().align_middle_y().align_middle_z()
+    }
+
+    /// Align the node to the bottom left of the last node.
+    fn bottom_left(self) -> Self {
+        self.align_left().align_bottom()
+    }
+
+    /// Align the node to the middle left of the last node.
+    fn mid_left(self) -> Self {
+        self.align_left().align_middle_y()
+    }
+
+    /// Align the node to the top left of the last node.
+    fn top_left(self) -> Self {
+        self.align_left().align_top()
+    }
+
+    /// Align the node to the middle top of the last node.
+    fn mid_top(self) -> Self {
+        self.align_middle_x().align_top()
+    }
+
+    /// Align the node to the top right of the last node.
+    fn top_right(self) -> Self {
+        self.align_right().align_top()
+    }
+
+    /// Align the node to the middle right of the last node.
+    fn mid_right(self) -> Self {
+        self.align_right().align_middle_y()
+    }
+
+    /// Align the node to the bottom right of the last node.
+    fn bottom_right(self) -> Self {
+        self.align_right().align_bottom()
+    }
+
+    /// Align the node to the middle bottom of the last node.
+    fn mid_bottom(self) -> Self {
+        self.align_middle_x().align_bottom()
+    }
+
+    /// Align the node in the middle of the given Node.
+    fn middle_of(self, other: node::Index) -> Self {
+        self.align_middle_x_of(other)
+            .align_middle_y_of(other)
+            .align_middle_z_of(other)
+    }
+
+    /// Align the node to the bottom left of the given Node.
+    fn bottom_left_of(self, other: node::Index) -> Self {
+        self.align_left_of(other).align_bottom_of(other)
+    }
+
+    /// Align the node to the middle left of the given Node.
+    fn mid_left_of(self, other: node::Index) -> Self {
+        self.align_left_of(other).align_middle_y_of(other)
+    }
+
+    /// Align the node to the top left of the given Node.
+    fn top_left_of(self, other: node::Index) -> Self {
+        self.align_left_of(other).align_top_of(other)
+    }
+
+    /// Align the node to the middle top of the given Node.
+    fn mid_top_of(self, other: node::Index) -> Self {
+        self.align_middle_x_of(other).align_top_of(other)
+    }
+
+    /// Align the node to the top right of the given Node.
+    fn top_right_of(self, other: node::Index) -> Self {
+        self.align_right_of(other).align_top_of(other)
+    }
+
+    /// Align the node to the middle right of the given Node.
+    fn mid_right_of(self, other: node::Index) -> Self {
+        self.align_right_of(other).align_middle_y_of(other)
+    }
+
+    /// Align the node to the bottom right of the given Node.
+    fn bottom_right_of(self, other: node::Index) -> Self {
+        self.align_right_of(other).align_bottom_of(other)
+    }
+
+    /// Align the node to the middle bottom of the given Node.
+    fn mid_bottom_of(self, other: node::Index) -> Self {
+        self.align_middle_x_of(other).align_bottom_of(other)
+    }
+}
+
+impl<S> SetPosition<S> for Properties<S> {
+    fn properties(&mut self) -> &mut Properties<S> {
+        self
+    }
+}
+
+impl<S> Default for Properties<S> {
+    fn default() -> Self {
+        let x = None;
+        let y = None;
+        let z = None;
+        Properties { x, y, z }
+    }
+}

--- a/src/draw/theme.rs
+++ b/src/draw/theme.rs
@@ -1,0 +1,43 @@
+use color::{Alpha, Rgb, Rgba};
+use std::collections::HashMap;
+
+/// A set of styling defaults used for coloring texturing geometric primitives that have no entry
+/// within the **Draw**'s inner **ColorMap**.
+#[derive(Clone, Debug, Default)]
+pub struct Theme {
+    /// Color defaults.
+    pub color: Color,
+}
+
+/// A set of defaults used for coloring.
+#[derive(Clone, Debug)]
+pub struct Color {
+    pub default: Rgba,
+    pub primitive: HashMap<Primitive, Rgba>,
+}
+
+/// Primitive geometry types that may have unique default styles.
+///
+/// These are used as keys into the **Theme**'s geometry primitive default values.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Primitive {
+    Cuboid,
+    Ellipse,
+    Line,
+    Polygon,
+    Polyline,
+    Quad,
+    Rect,
+    Tri,
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        let default = Alpha {
+            color: Rgb::new(1.0, 1.0, 1.0),
+            alpha: 1.0,
+        };
+        let primitive = Default::default();
+        Color { default, primitive }
+    }
+}

--- a/src/geom/ellipse.rs
+++ b/src/geom/ellipse.rs
@@ -31,7 +31,7 @@ pub struct Section<S = f64> {
 pub struct Circumference<S = f64> {
     index: usize,
     num_points: usize,
-    point: Point2<S>,
+    middle: Point2<S>,
     rad_step: S,
     rad_offset: S,
     half_w: S,
@@ -118,7 +118,7 @@ where
         Circumference {
             index: 0,
             num_points: num_points,
-            point: [x, y].into(),
+            middle: [x, y].into(),
             half_w: w / two,
             half_h: h / two,
             rad_step: rad_step,
@@ -177,7 +177,7 @@ where
     where
         S: Float,
     {
-        let last = self.next().unwrap_or(self.point);
+        let last = self.next().unwrap_or(self.middle);
         Triangles { last, points: self }
     }
 }
@@ -191,7 +191,7 @@ where
         let Circumference {
             ref mut index,
             num_points,
-            point,
+            middle,
             rad_step,
             rad_offset,
             half_w,
@@ -201,8 +201,8 @@ where
             return None;
         }
         let index_s: S = NumCast::from(*index).unwrap();
-        let x = point.x + half_w * (rad_offset + rad_step * index_s).cos();
-        let y = point.y + half_h * (rad_offset + rad_step * index_s).sin();
+        let x = middle.x + half_w * (rad_offset + rad_step * index_s).cos();
+        let y = middle.y + half_h * (rad_offset + rad_step * index_s).sin();
         *index += 1;
         Some([x, y].into())
     }
@@ -237,7 +237,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let Triangles { ref mut points, ref mut last } = *self;
         points.next().map(|next| {
-            let triangle = Tri([points.point, *last, next]);
+            let triangle = Tri([points.middle, *last, next]);
             *last = next;
             triangle
         })

--- a/src/geom/graph/edge.rs
+++ b/src/geom/graph/edge.rs
@@ -1,5 +1,6 @@
 //! Items related to the edges of a geometry graph.
 use daggy;
+use math::{BaseFloat, Euler, Rad, Vector3};
 
 /// Unique index for an **Edge** within a **Graph**.
 pub type Index = daggy::EdgeIndex<usize>;
@@ -186,4 +187,19 @@ impl<S> Edge<S> {
     pub fn z_scale(weight: S) -> Self {
         Edge::new(Kind::z_scale(), weight)
     }
+}
+
+/// The three edges describing the given position displacement.
+pub fn displace<S>(v: Vector3<S>) -> [Edge<S>; 3] {
+    [Edge::x_position(v.x), Edge::y_position(v.y), Edge::z_position(v.z)]
+}
+
+/// The three edges describing the given orientation rotation.
+pub fn rotate<S: BaseFloat>(e: Euler<Rad<S>>) -> [Edge<S>; 3] {
+    [Edge::x_orientation(e.x.0), Edge::y_orientation(e.x.0), Edge::z_orientation(e.z.0)]
+}
+
+/// An edge for scaling each axis using the given single scalar scale value.
+pub fn scale<S: Copy>(scale: S) -> [Edge<S>; 3] {
+    [Edge::x_scale(scale), Edge::y_scale(scale), Edge::z_scale(scale)]
 }

--- a/src/geom/graph/edge.rs
+++ b/src/geom/graph/edge.rs
@@ -76,6 +76,24 @@ impl Kind {
         Kind::new(Axis::Z, relative)
     }
 
+    /// Simple constructor for an Edge describing a relative position along the given axis.
+    pub fn position(axis: Axis) -> Self {
+        let relative = Relative::Position;
+        Kind { axis, relative }
+    }
+
+    /// Simple constructor for an Edge describing a relative orientation along the given axis.
+    pub fn orientation(axis: Axis) -> Self {
+        let relative = Relative::Orientation;
+        Kind { axis, relative }
+    }
+
+    /// Simple constructor for an Edge describing a relative scale along the given axis.
+    pub fn scale(axis: Axis) -> Self {
+        let relative = Relative::Scale;
+        Kind { axis, relative }
+    }
+
     /// Simple constructor for and Edge describing a relative position over the **X** axis.
     pub fn x_position() -> Self {
         Kind::x(Relative::Position)
@@ -141,6 +159,21 @@ impl<S> Edge<S> {
     /// Simple constructor for an `Edge` describing a relative association over the **Z** axis.
     pub fn z(relative: Relative, weight: S) -> Self {
         Edge::new(Kind::z(relative), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative position over the given axis.
+    pub fn position(axis: Axis, weight: S) -> Self {
+        Edge::new(Kind::position(axis), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative orientation over the given axis.
+    pub fn orientation(axis: Axis, weight: S) -> Self {
+        Edge::new(Kind::orientation(axis), weight)
+    }
+
+    /// Simple constructor for an `Edge` describing a relative scale over the given axis.
+    pub fn scale(axis: Axis, weight: S) -> Self {
+        Edge::new(Kind::scale(axis), weight)
     }
 
     /// Simple constructor for an `Edge` describing a relative position over the **X** axis.

--- a/src/geom/graph/node.rs
+++ b/src/geom/graph/node.rs
@@ -5,66 +5,12 @@ use daggy::petgraph::visit::{self, Visitable};
 use geom;
 use geom::{DefaultScalar, Graph};
 use geom::graph::Edge;
-use math::{self, BaseFloat, Basis3, Euler, Point2, Point3, Rad, Rotation, Vector3, Zero};
+use math::{self, BaseFloat, Basis3, Euler, Point3, Rad, Rotation, Vector3, Zero};
 use std::collections::HashMap;
-use std::{iter, ops, slice};
+use std::ops;
 
 /// Unique index for a **Node** within a **Graph**.
 pub type Index = daggy::NodeIndex<usize>;
-
-/// Each of the primitive graphics types that may be instantiated within the graph.
-///
-/// Primitives that are described by a dynamic number of vertices share a single vertex buffer
-/// that is owned by the graph. These variants store a range into this vertex buffer indicating
-/// which slice of vertices describe it.
-#[derive(Clone, Debug)]
-pub enum Primitive<S = DefaultScalar> {
-    Cuboid(geom::Cuboid<S>),
-    Ellipse(geom::Ellipse<S>),
-    Line(geom::Line<S>),
-    Polygon {
-        range: ops::Range<usize>,
-    },
-    Polyline {
-        join: geom::polyline::join::Dynamic,
-        cap: geom::polyline::cap::Dynamic,
-        range: ops::Range<usize>,
-        thickness: S,
-    },
-    Quad(geom::Quad<Point3<S>>),
-    Rect(geom::Rect<S>),
-    Tri(geom::Tri<Point3<S>>),
-}
-
-/// An iterator yielding all vertices for a primitive.
-#[derive(Clone)]
-pub enum PrimitiveVertices<'a, S: 'a = DefaultScalar> {
-    Cuboid(geom::cuboid::Corners<'a, S>),
-    Ellipse(geom::ellipse::Circumference<S>),
-    Line(geom::line::Vertices<S>),
-    Polygon(iter::Cloned<slice::Iter<'a, Point3<S>>>),
-    // TODO: Add a `polyline::Part::vertices` method and use `polyline::Vertices` instead.
-    //Polyline(geom::polyline::DynamicTriangles<slice::Iter<'a, Point3<S>>, S>),
-    Quad(geom::quad::Vertices<Point3<S>>),
-    Rect(geom::rect::Corners<S>),
-    Tri(geom::tri::Vertices<Point3<S>>),
-}
-
-/// An iterator yielding all triangles for a primitive.
-#[derive(Clone)]
-pub enum PrimitiveTriangles<'a, S: 'a = DefaultScalar>
-where
-    S: BaseFloat,
-{
-    Cuboid(geom::cuboid::Triangles<'a, S>),
-    Ellipse(geom::ellipse::Triangles<S>),
-    Line(geom::line::Triangles<S>),
-    Polygon(Option<geom::polygon::Triangles<iter::Cloned<slice::Iter<'a, Point3<S>>>>>),
-    Polyline(geom::polyline::DynamicTriangles<iter::Cloned<slice::Iter<'a, Point3<S>>>>),
-    Quad(geom::quad::Triangles<Point3<S>>),
-    Rect(geom::rect::Triangles<S>),
-    Tri(Option<geom::Tri<Point3<S>>>),
-}
 
 /// The **Node** type used within the **Graph**.
 #[derive(Clone, Debug)]
@@ -78,51 +24,29 @@ where
     ///
     /// Also used to represent the graph's "origin" node.
     Point,
-    /// A node representing some primitive geometric type (e.g. `Tri`, `Cuboid`, `Quad`, etc).
-    Primitive(Primitive<S>),
     /// A nested Graph.
     Graph {
         graph: super::Graph<S>,
         dfs: Dfs<S>,
     },
 }
-
-/// An iterator yielding all vertices from a node.
-pub enum Vertices<'a, S: 'a = DefaultScalar>
-where
-    S: BaseFloat,
-{
-    Point(Option<Point3<S>>),
-    Primitive(PrimitiveVertices<'a, S>),
-    Graph(geom::graph::Vertices<'a, S>),
-}
-
-/// An iterator yielding all triangles from a node.
-pub enum Triangles<'a, S: 'a = DefaultScalar>
-where
-    S: BaseFloat,
-{
-    Point,
-    Primitive(PrimitiveTriangles<'a, S>),
-    Graph(geom::graph::Triangles<'a, S>),
-}
-
+ 
 /// An iterator yielding all vertices for a node transformed by some given transform.
-pub struct TransformedVertices<'a, S: 'a = DefaultScalar>
+pub struct TransformedVertices<I, S = DefaultScalar>
 where
     S: BaseFloat,
 {
     transform: Transform<S>,
-    vertices: Vertices<'a, S>,
+    vertices: I,
 }
 
 /// An iterator yielding all vertices for a node transformed by some given transform.
-pub struct TransformedTriangles<'a, S: 'a = DefaultScalar>
+pub struct TransformedTriangles<I, S = DefaultScalar>
 where
     S: BaseFloat,
 {
     transform: Transform<S>,
-    triangles: Triangles<'a, S>,
+    triangles: I,
 }
 
 /// A node's resulting rotation, displacement and scale relative to the graph's origin.
@@ -149,6 +73,17 @@ where
     ///
     /// This vector is added onto the position of each vertex of the node.
     pub disp: Vector3<S>,
+}
+
+/// Mappings from node indices to their respective transform within the graph.
+///
+/// This is calculated via the `Graph::update_transform_map` method.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransformMap<S = DefaultScalar>
+where
+    S: BaseFloat,
+{
+    map: HashMap<Index, Transform<S>>
 }
 
 /// A depth-first-search over nodes in the graph, yielding each node's unique index alongside its
@@ -213,21 +148,23 @@ where
 
     /// Return the vertices for the next node in the DFS.
     ///
-    /// Uses `Dfs::next_transform` and `Node::vertices` internally.
+    /// Uses `Dfs::next_transform` internally.
     ///
     /// Returns `None` if the traversal is finished.
-    pub fn next_vertices<'a>(
+    pub fn next_vertices<F, I>(
         &mut self,
-        graph: &'a Graph<S>,
-    ) -> Option<(Index, TransformedVertices<'a, S>)>
+        graph: &Graph<S>,
+        vertices_fn: F,
+    ) -> Option<(Index, TransformedVertices<I::IntoIter, S>)>
+    where
+        F: FnOnce(&Index) -> I,
+        I: IntoIterator<Item = Point3<S>>,
     {
         self.next_transform(graph)
-            .and_then(|(n, transform)| {
-                graph.node(n)
-                    .map(|node| {
-                        let vertices = node.vertices(&graph.vertices);
-                        (n, TransformedVertices { vertices, transform })
-                    })
+            .map(|(n, transform)| {
+                let vertices = vertices_fn(&n);
+                let vertices = vertices.into_iter();
+                (n, TransformedVertices { vertices, transform })
             })
     }
 
@@ -236,18 +173,20 @@ where
     /// Uses `Dfs::next_transform` and `Node::triangles` internally.
     ///
     /// Returns `None` if the traversal is finished.
-    pub fn next_triangles<'a>(
+    pub fn next_triangles<F, I>(
         &mut self,
-        graph: &'a Graph<S>,
-    ) -> Option<(Index, TransformedTriangles<'a, S>)>
+        graph: &Graph<S>,
+        triangles_fn: F,
+    ) -> Option<(Index, TransformedTriangles<I::IntoIter, S>)>
+    where
+        F: FnOnce(&Index) -> I,
+        I: IntoIterator<Item = geom::Tri<Point3<S>>>,
     {
         self.next_transform(graph)
-            .and_then(|(n, transform)| {
-                graph.node(n)
-                    .map(|node| {
-                        let triangles = node.triangles(&graph.vertices);
-                        (n, TransformedTriangles { triangles, transform })
-                    })
+            .map(|(n, transform)| {
+                let triangles = triangles_fn(&n);
+                let triangles = triangles.into_iter();
+                (n, TransformedTriangles { triangles, transform })
             })
     }
 }
@@ -260,17 +199,6 @@ where
     fn walk_next(&mut self, graph: &'a Graph<S>) -> Option<Self::Item> {
         self.next_transform(graph)
     }
-}
-
-/// Mappings from node indices to their respective transform within the graph.
-///
-/// This is calculated via the `Graph::update_transform_map` method.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TransformMap<S = DefaultScalar>
-where
-    S: BaseFloat,
-{
-    map: HashMap<Index, Transform<S>>
 }
 
 impl<S> Default for TransformMap<S>
@@ -392,8 +320,9 @@ where
     point
 }
 
-impl<'a, S> Iterator for TransformedVertices<'a, S>
+impl<I, S> Iterator for TransformedVertices<I, S>
 where
+    I: Iterator<Item = Point3<S>>,
     S: BaseFloat,
 {
     type Item = Point3<S>;
@@ -404,320 +333,15 @@ where
     }
 }
 
-impl<'a, S> Iterator for TransformedTriangles<'a, S>
+impl<I, S> Iterator for TransformedTriangles<I, S>
 where
+    I: Iterator<Item = geom::Tri<Point3<S>>>,
     S: BaseFloat,
 {
     type Item = geom::Tri<Point3<S>>;
     fn next(&mut self) -> Option<Self::Item> {
         self.triangles
             .next()
-            .map(|tri| tri.map(|point| transform_point(&self.transform, point)))
-    }
-}
-
-impl<S> Primitive<S>
-where
-    S: BaseFloat,
-{
-    /// The `Cuboid` that bounds the primitive.
-    ///
-    /// Returns `None` if the primitive is a polygon or polyline with no points.
-    pub fn bounding_cuboid(&self, vertices: &[Point3<S>]) -> Option<geom::Cuboid<S>> {
-        match *self {
-            Primitive::Cuboid(ref cuboid) => {
-                geom::bounding_cuboid(cuboid.corners_iter())
-            },
-            Primitive::Ellipse(ref ellipse) => {
-                let (x, y) = (ellipse.rect.x, ellipse.rect.y);
-                let z = geom::Range::new(Zero::zero(), Zero::zero());
-                Some(geom::Cuboid { x, y, z })
-            },
-            Primitive::Line(ref line) => {
-                let q = line.quad_corners();
-                let vertices = q.iter()
-                    .map(|p| {
-                        let x = p.x;
-                        let y = p.y;
-                        let z = Zero::zero();
-                        Point3 { x, y, z }
-                    });
-                geom::bounding_cuboid(vertices)
-            },
-            Primitive::Polygon { ref range } => {
-                let vertices = vertices[range.clone()].iter().cloned();
-                geom::bounding_cuboid(vertices)
-            },
-            Primitive::Polyline { join, cap, ref range, thickness } => {
-                let vertices = vertices[range.clone()]
-                    .iter()
-                    .cloned()
-                    .map(|p| Point2 { x: p.x, y: p.y });
-                geom::Polyline::new(cap, join, vertices, thickness)
-                    .bounding_rect()
-                    .map(|rect| {
-                        let (x, y) = (rect.x, rect.y);
-                        let z = geom::Range::new(Zero::zero(), Zero::zero());
-                        geom::Cuboid { x, y, z }
-                    })
-            },
-            Primitive::Quad(ref quad) => {
-                let vertices = quad.iter().cloned();
-                geom::bounding_cuboid(vertices)
-            },
-            Primitive::Rect(ref rect) => {
-                let (x, y) = (rect.x, rect.y);
-                let z = geom::Range::new(Zero::zero(), Zero::zero());
-                Some(geom::Cuboid { x, y, z })
-            },
-            Primitive::Tri(ref tri) => {
-                let r = tri.bounding_rect();
-                let (x, y) = (r.x, r.y);
-                let z = geom::Range::new(Zero::zero(), Zero::zero());
-                Some(geom::Cuboid { x, y, z })
-            },
-        }
-    }
-
-    /// Produce an iterator yielding all vertices within the primitive.
-    pub fn vertices<'a>(&'a self, vertices: &'a [Point3<S>]) -> PrimitiveVertices<'a, S> {
-        match *self {
-            Primitive::Cuboid(ref cuboid) => {
-                PrimitiveVertices::Cuboid(cuboid.corners_iter())
-            },
-            Primitive::Ellipse(ref ellipse) => {
-                PrimitiveVertices::Ellipse(ellipse.circumference())
-            },
-            Primitive::Line(ref line) => {
-                PrimitiveVertices::Line(line.quad_corners_iter())
-            },
-            Primitive::Polygon { ref range } => {
-                let slice = &vertices[range.clone()];
-                PrimitiveVertices::Polygon(slice.iter().cloned())
-            },
-            Primitive::Polyline { .. } => {
-                unimplemented!();
-            },
-            Primitive::Quad(ref quad) => {
-                PrimitiveVertices::Quad(quad.vertices())
-            },
-            Primitive::Rect(ref rect) => {
-                PrimitiveVertices::Rect(rect.corners_iter())
-            },
-            Primitive::Tri(ref tri) => {
-                PrimitiveVertices::Tri(tri.vertices())
-            },
-        }
-    }
-
-    /// Produce an iterator yielding all triangles within the primitive.
-    pub fn triangles<'a>(&'a self, vertices: &'a [Point3<S>]) -> PrimitiveTriangles<'a, S> {
-        match *self {
-            Primitive::Cuboid(ref cuboid) => {
-                PrimitiveTriangles::Cuboid(cuboid.triangles_iter())
-            },
-            Primitive::Ellipse(ref ellipse) => {
-                PrimitiveTriangles::Ellipse(ellipse.triangles())
-            },
-            Primitive::Line(ref line) => {
-                PrimitiveTriangles::Line(line.triangles_iter())
-            },
-            Primitive::Polygon { ref range } => {
-                let slice = &vertices[range.clone()];
-                let polygon = geom::Polygon::new(slice.iter().cloned());
-                PrimitiveTriangles::Polygon(polygon.triangles())
-            },
-            Primitive::Polyline { .. } => {
-                unimplemented!();
-            },
-            Primitive::Quad(ref quad) => {
-                PrimitiveTriangles::Quad(quad.triangles_iter())
-            },
-            Primitive::Rect(ref rect) => {
-                PrimitiveTriangles::Rect(rect.triangles_iter())
-            },
-            Primitive::Tri(ref tri) => {
-                PrimitiveTriangles::Tri(Some(*tri))
-            },
-        }
-    }
-}
-
-// A small function used for mapping 2D points to 3D ones within the PrimitiveVertices and
-// PrimitiveTriangles iterators.
-fn pt2_to_pt3<S>(p: Point2<S>) -> Point3<S>
-where
-    S: BaseFloat,
-{
-    let x = p.x;
-    let y = p.y;
-    let z = Zero::zero();
-    Point3 { x, y, z }
-}
-
-impl<'a, S> Iterator for PrimitiveVertices<'a, S>
-where
-    S: BaseFloat,
-{
-    type Item = Point3<S>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            PrimitiveVertices::Cuboid(ref mut corners) => {
-                corners.next()
-            },
-            PrimitiveVertices::Ellipse(ref mut circumference) => {
-                circumference.next().map(pt2_to_pt3)
-            },
-            PrimitiveVertices::Line(ref mut vertices) => {
-                vertices.next().map(pt2_to_pt3)
-            },
-            PrimitiveVertices::Polygon(ref mut vertices) => {
-                vertices.next()
-            },
-            // PrimitiveVertices::Polyline(ref mut vertices) => {
-            //     vertices.next()
-            // },
-            PrimitiveVertices::Quad(ref mut vertices) => {
-                vertices.next()
-            },
-            PrimitiveVertices::Rect(ref mut corners) => {
-                corners.next().map(pt2_to_pt3)
-            },
-            PrimitiveVertices::Tri(ref mut vertices) => {
-                vertices.next()
-            },
-        }
-    }
-}
-
-impl<'a, S> Iterator for PrimitiveTriangles<'a, S>
-where
-    S: BaseFloat,
-{
-    type Item = geom::Tri<Point3<S>>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            PrimitiveTriangles::Cuboid(ref mut tris) => {
-                tris.next()
-            },
-            PrimitiveTriangles::Ellipse(ref mut tris) => {
-                tris.next().map(|t| t.map(pt2_to_pt3))
-            },
-            PrimitiveTriangles::Line(ref mut tris) => {
-                tris.next().map(|t| t.map(pt2_to_pt3))
-            },
-            PrimitiveTriangles::Polygon(ref mut tris) => {
-                tris.as_mut().and_then(|ts| ts.next())
-            },
-            PrimitiveTriangles::Polyline(ref mut _tris) => {
-                unimplemented!();
-                // TODO: Implement Iterator for DynamicTriangles
-                //tris.next().map(|t| t.map(pt2_to_pt3))
-            },
-            PrimitiveTriangles::Quad(ref mut tris) => {
-                tris.next()
-            },
-            PrimitiveTriangles::Rect(ref mut tris) => {
-                tris.next().map(|t| t.map(pt2_to_pt3))
-            },
-            PrimitiveTriangles::Tri(ref mut tri) => {
-                tri.take()
-            },
-        }
-    }
-}
-
-impl<'a, S> Iterator for Vertices<'a, S>
-where
-    S: BaseFloat,
-{
-    type Item = Point3<S>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            // A node point is always at the node's origin.
-            Vertices::Point(ref mut point) => {
-                point.take()
-            },
-            Vertices::Primitive(ref mut vertices) => {
-                vertices.next()
-            },
-            Vertices::Graph(ref mut vertices) => {
-                vertices.next()
-            },
-        }
-    }
-}
-
-impl<'a, S> Iterator for Triangles<'a, S>
-where
-    S: BaseFloat,
-{
-    type Item = geom::Tri<Point3<S>>;
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            Triangles::Point => {
-                None
-            },
-            Triangles::Primitive(ref mut triangles) => {
-                triangles.next()
-            },
-            Triangles::Graph(ref mut triangles) => {
-                triangles.next()
-            },
-        }
-    }
-}
-
-impl<S> Node<S>
-where
-    S: BaseFloat,
-{
-    /// The `Cuboid` that bounds the primitive.
-    ///
-    /// Returns `None` if the primitive is a polygon, polyline or graph with no points.
-    pub fn bounding_cuboid(&self, vertices: &[Point3<S>]) -> Option<geom::Cuboid<S>> {
-        match *self {
-            Node::Point => {
-                let zero = Zero::zero();
-                let x = geom::Range::new(zero, zero);
-                let y = geom::Range::new(zero, zero);
-                let z = geom::Range::new(zero, zero);
-                Some(geom::Cuboid { x, y, z })
-            },
-            Node::Primitive(ref primitive) => primitive.bounding_cuboid(vertices),
-            Node::Graph { ref graph, .. } => graph.bounding_cuboid(),
-        }
-    }
-
-    /// Produce an iterator yielding all vertices within the node.
-    pub fn vertices<'a>(&'a self, vertices: &'a [Point3<S>]) -> Vertices<'a, S> {
-        match *self {
-            Node::Point => {
-                let zero = Zero::zero();
-                let (x, y, z) = (zero, zero, zero);
-                Vertices::Point(Some(Point3 { x, y, z }))
-            },
-            Node::Primitive(ref primitive) => {
-                Vertices::Primitive(primitive.vertices(vertices))
-            },
-            Node::Graph { .. } => {
-                unimplemented!();
-            },
-        }
-    }
-
-    /// Produce an iterator yielding all triangles within the node.
-    pub fn triangles<'a>(&'a self, vertices: &'a [Point3<S>]) -> Triangles<'a, S> {
-        match *self {
-            Node::Point => {
-                Triangles::Point
-            },
-            Node::Primitive(ref primitive) => {
-                Triangles::Primitive(primitive.triangles(vertices))
-            },
-            Node::Graph { .. } => {
-                unimplemented!();
-            }
-        }
+            .map(|tri| tri.map_vertices(|point| transform_point(&self.transform, point)))
     }
 }

--- a/src/geom/polygon.rs
+++ b/src/geom/polygon.rs
@@ -5,7 +5,7 @@ use geom::tri::{self, Tri};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Polygon<I> {
     /// The iterator yielding all points in the polygon.
-    points: I,
+    pub points: I,
 }
 
 impl<I> Polygon<I>

--- a/src/geom/polyline.rs
+++ b/src/geom/polyline.rs
@@ -195,6 +195,24 @@ pub mod join {
         Bevel(Bevel),
     }
 
+    impl From<Miter> for Dynamic {
+        fn from(miter: Miter) -> Self {
+            Dynamic::Miter(miter)
+        }
+    }
+
+    impl From<Round> for Dynamic {
+        fn from(round: Round) -> Self {
+            Dynamic::Round(round)
+        }
+    }
+
+    impl From<Bevel> for Dynamic {
+        fn from(bevel: Bevel) -> Self {
+            Dynamic::Bevel(bevel)
+        }
+    }
+
     pub type MiterTris<S> = quad::Triangles<Point2<S>>;
     pub type RoundTris<S> = ellipse::Triangles<S>;
     pub type BevelTris<S> = iter::Once<Tri<Point2<S>>>;
@@ -385,6 +403,24 @@ pub mod cap {
         Butt(Butt),
         Round(Round),
         Square(Square),
+    }
+
+    impl From<Butt> for Dynamic {
+        fn from(butt: Butt) -> Self {
+            Dynamic::Butt(butt)
+        }
+    }
+
+    impl From<Round> for Dynamic {
+        fn from(round: Round) -> Self {
+            Dynamic::Round(round)
+        }
+    }
+
+    impl From<Square> for Dynamic {
+        fn from(square: Square) -> Self {
+            Dynamic::Square(square)
+        }
     }
 
     pub type ButtTris<S> = iter::Empty<Tri<Point2<S>>>;

--- a/src/geom/rect.rs
+++ b/src/geom/rect.rs
@@ -117,6 +117,12 @@ where
         }
     }
 
+    /// Construct a Rect at origin with the given dimensions.
+    pub fn from_wh(wh: Vector2<S>) -> Self {
+        let p = Point2 { x: S::zero(), y: S::zero() };
+        Self::from_xy_wh(p, wh)
+    }
+
     /// Construct a Rect from the coordinates of two points.
     pub fn from_corners(a: Point2<S>, b: Point2<S>) -> Self {
         let (left, right) = if a.x < b.x { (a.x, b.x) } else { (b.x, a.x) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub extern crate daggy;
 pub extern crate find_folder;
-pub extern crate glium;
+#[macro_use] pub extern crate glium;
 pub extern crate rand;
 
 use event::LoopEvent;
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::time::Instant;
 
 pub use app::{App, LoopMode};
+pub use draw::Draw;
 pub use glium::glutin::{ContextBuilder, CursorState, ElementState, MonitorId, MouseCursor,
                         WindowBuilder, WindowEvent, VirtualKeyCode};
 pub use self::event::Event;
@@ -18,12 +19,14 @@ pub use self::ui::Ui;
 pub mod app;
 pub mod audio;
 pub mod color;
+pub mod draw;
 pub mod ease;
 pub mod event;
 mod frame;
 pub mod geom;
 pub mod image;
 pub mod math;
+pub mod mesh;
 pub mod osc;
 pub mod prelude;
 pub mod state;
@@ -177,10 +180,12 @@ where
 
                 // If the window ID has changed, ensure the dimensions are up to date.
                 if app.window.id != Some(window_id) {
-                    app.window.id = Some(window_id);
-                    app.window.width = tw(win_w as f64);
-                    app.window.height = th(win_h as f64);
-                    app.window.hidpi_factor = hidpi_factor;
+                    if app.window(window_id).is_some() {
+                        app.window.id = Some(window_id);
+                        app.window.width = tw(win_w as f64);
+                        app.window.height = th(win_h as f64);
+                        app.window.hidpi_factor = hidpi_factor;
+                    }
                 }
 
                 // Check for events that would update either mouse, keyboard or window state.

--- a/src/mesh/channel.rs
+++ b/src/mesh/channel.rs
@@ -1,0 +1,116 @@
+use std::borrow::{Borrow, Cow};
+
+/// Types that may be used as a data channel within a mesh.
+pub trait Channel {
+    /// The type contained within the channel.
+    type Element;
+    /// Borrow the data channel.
+    fn channel(&self) -> &[Self::Element];
+}
+
+/// Types that may be used as a data channel within a mesh.
+pub trait ChannelMut: Channel {
+    /// Mutably borrow the data channel.
+    fn channel_mut(&mut self) -> &mut [Self::Element];
+}
+
+// /// Types that may be used as a constant-length buffer underlying a `Bounded` ring buffer.
+// pub trait FixedSizeArray {
+//     /// The constant length.
+//     const LEN: usize;
+// }
+
+impl<'a, T> Channel for &'a [T] {
+    type Element = T;
+    #[inline]
+    fn channel(&self) -> &[Self::Element] {
+        self
+    }
+}
+
+impl<'a, T> Channel for &'a mut [T] {
+    type Element = T;
+    #[inline]
+    fn channel(&self) -> &[Self::Element] {
+        self
+    }
+}
+
+impl<'a, T> ChannelMut for &'a mut [T] {
+    #[inline]
+    fn channel_mut(&mut self) -> &mut [Self::Element] {
+        self
+    }
+}
+
+impl<T> Channel for Box<[T]> {
+    type Element = T;
+    #[inline]
+    fn channel(&self) -> &[Self::Element] {
+        &self[..]
+    }
+}
+
+impl<T> ChannelMut for Box<[T]> {
+    #[inline]
+    fn channel_mut(&mut self) -> &mut [Self::Element] {
+        &mut self[..]
+    }
+}
+
+impl<T> Channel for Vec<T> {
+    type Element = T;
+    #[inline]
+    fn channel(&self) -> &[Self::Element] {
+        &self[..]
+    }
+}
+
+impl<T> ChannelMut for Vec<T> {
+    #[inline]
+    fn channel_mut(&mut self) -> &mut [Self::Element] {
+        &mut self[..]
+    }
+}
+
+impl<'a, T> Channel for Cow<'a, [T]>
+where
+    [T]: ToOwned,
+{
+    type Element = T;
+    #[inline]
+    fn channel(&self) -> &[Self::Element] {
+        self.borrow()
+    }
+}
+
+macro_rules! impl_channel_for_arrays {
+    ($($N:expr)*) => {
+        $(
+            impl<T> Channel for [T; $N] {
+                type Element = T;
+                #[inline]
+                fn channel(&self) -> &[Self::Element] {
+                    &self[..]
+                }
+            }
+            impl<T> ChannelMut for [T; $N] {
+                #[inline]
+                fn channel_mut(&mut self) -> &mut [Self::Element] {
+                    &mut self[..]
+                }
+            }
+            // impl<T> FixedSizeArray for [T; $N] {
+            //     const LEN: usize = $N;
+            // }
+        )*
+    };
+}
+
+impl_channel_for_arrays! {
+    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
+    35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65
+    66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96
+    97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120
+    121 122 123 124 125 126 127 128 256 512 1024 2048 4096 8192
+}

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -1,0 +1,818 @@
+use geom;
+use math::{BaseFloat, BaseNum, EuclideanSpace, Point2};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+pub mod channel;
+pub mod vertex;
+
+pub use self::channel::{Channel, ChannelMut};
+
+// Type aliases.
+
+/// The fallback scalar type used for texture coordinates if none is specified.
+pub type TexCoordScalarDefault = f64;
+
+// Traits describing meshes with access to certain channels.
+
+/// Mesh types that can be indexed to produce a vertex.
+pub trait GetVertex {
+    /// The vertex type representing all channels of data within the mesh at a single index.
+    type Vertex;
+    /// Create a vertex containing all channel properties for the given index.
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex>;
+}
+
+/// All meshes must contain at least one vertex channel.
+pub trait Points {
+    /// The scalar value used for the vertex coordinates.
+    type Scalar: BaseNum;
+    /// The vertex type used to represent the location of a vertex.
+    type Point: geom::Vertex<Scalar = Self::Scalar>;
+    /// The channel type containing points.
+    type Points: Channel<Element = Self::Point>;
+    /// Borrow the vertex channel from the mesh.
+    fn points(&self) -> &Self::Points;
+}
+
+/// Meshes that contain a channel of indices that describe the edges between points.
+pub trait Indices {
+    /// The channel type containing indices.
+    type Indices: Channel<Element = usize>;
+    /// Borrow the index channel from the mesh.
+    fn indices(&self) -> &Self::Indices;
+}
+
+/// Meshes that contain a channel of colors.
+pub trait Colors {
+    /// The color type stored within the channel.
+    type Color;
+    /// The channel type containing colors.
+    type Colors: Channel<Element = Self::Color>;
+    /// Borrow the color channel from the mesh.
+    fn colors(&self) -> &Self::Colors;
+}
+
+/// Meshes that contain a channel of texture coordinates.
+pub trait TexCoords {
+    /// The scalar value used for the texture coordinates.
+    type TexCoordScalar: BaseFloat;
+    /// The channel type containing texture coordinates.
+    type TexCoords: Channel<Element = Point2<Self::TexCoordScalar>>;
+    /// Borrow the texture coordinate channel from the mesh.
+    fn tex_coords(&self) -> &Self::TexCoords;
+}
+
+/// Meshes that contain a channel of vertex normals.
+pub trait Normals: Points
+where
+    Self::Point: EuclideanSpace,
+{
+    /// The channel type containing vertex normals.
+    type Normals: Channel<Element = <Self::Point as EuclideanSpace>::Diff>;
+    /// Borrow the normal channel from the mesh.
+    fn normals(&self) -> &Self::Normals;
+}
+
+// Mesh types.
+
+/// The base mesh type with only a single vertex channel.
+///
+/// Extra channels can be added to the mesh via the `WithIndices`, `WithColors`, `WithTexCoords`
+/// and `WithNormals` adaptor types.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct MeshPoints<P> {
+    pub points: P,
+}
+
+/// A mesh type with an added channel containing indices describing the edges between vertices.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithIndices<M, I> {
+    pub mesh: M,
+    pub indices: I,
+}
+
+/// A `Mesh` type with an added channel containing colors.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithColors<M, C> {
+    pub mesh: M,
+    pub colors: C,
+}
+
+/// A `Mesh` type with an added channel containing texture coordinates.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithTexCoords<M, T, S = TexCoordScalarDefault> {
+    pub mesh: M,
+    pub tex_coords: T,
+    pub _tex_coord_scalar: PhantomData<S>, // Required due to lack of HKT.
+}
+
+/// A `Mesh` type with an added channel containing vertex normals.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithNormals<M, N> {
+    pub mesh: M,
+    pub normals: N,
+}
+
+// **GetVertex** implementations.
+
+impl<'a, M> GetVertex for &'a M
+where
+    M: GetVertex,
+{
+    type Vertex = M::Vertex;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        (**self).get_vertex(index)
+    }
+}
+
+impl<'a, M> GetVertex for &'a mut M
+where
+    M: GetVertex,
+{
+    type Vertex = M::Vertex;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        (**self).get_vertex(index)
+    }
+}
+
+impl<P> GetVertex for MeshPoints<P>
+where
+    P: Channel,
+    P::Element: geom::Vertex,
+{
+    type Vertex = P::Element;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.points.channel().get(index).map(|&p| p)
+    }
+}
+
+impl<M, I> GetVertex for WithIndices<M, I>
+where
+    M: GetVertex,
+{
+    type Vertex = M::Vertex;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.mesh.get_vertex(index)
+    }
+}
+
+impl<M, C> GetVertex for WithColors<M, C>
+where
+    M: GetVertex,
+    C: Channel,
+    C::Element: Clone,
+{
+    type Vertex = vertex::WithColor<M::Vertex, C::Element>;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.mesh.get_vertex(index)
+            .and_then(|vertex| {
+                self.colors.channel()
+                    .get(index)
+                    .map(|color| {
+                        let color = color.clone();
+                        vertex::WithColor { vertex, color }
+                    })
+            })
+    }
+}
+
+impl<M, T, S> GetVertex for WithTexCoords<M, T, S>
+where
+    M: GetVertex,
+    T: Channel,
+    T::Element: Clone,
+{
+    type Vertex = vertex::WithTexCoords<M::Vertex, T::Element>;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.mesh.get_vertex(index)
+            .and_then(|vertex| {
+                self.tex_coords.channel()
+                    .get(index)
+                    .map(|tex_coords| {
+                        let tex_coords = tex_coords.clone();
+                        vertex::WithTexCoords { vertex, tex_coords }
+                    })
+            })
+    }
+}
+
+impl<M, N> GetVertex for WithNormals<M, N>
+where
+    M: GetVertex,
+    N: Channel,
+    N::Element: Clone,
+{
+    type Vertex = vertex::WithNormal<M::Vertex, N::Element>;
+    fn get_vertex(&self, index: usize) -> Option<Self::Vertex> {
+        self.mesh.get_vertex(index)
+            .and_then(|vertex| {
+                self.normals.channel()
+                    .get(index)
+                    .map(|normal| {
+                        let normal = normal.clone();
+                        vertex::WithNormal { vertex, normal }
+                    })
+            })
+    }
+}
+
+// **Points** implementations.
+
+impl<P> Points for MeshPoints<P>
+where
+    P: Channel,
+    P::Element: geom::Vertex,
+{
+    type Scalar = <P::Element as geom::Vertex>::Scalar;
+    type Point = P::Element;
+    type Points = P;
+    fn points(&self) -> &Self::Points {
+        &self.points
+    }
+}
+
+impl<'a, M> Points for &'a M
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        (**self).points()
+    }
+}
+
+impl<'a, M> Points for &'a mut M
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        (**self).points()
+    }
+}
+
+impl<M, I> Points for WithIndices<M, I>
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        self.mesh.points()
+    }
+}
+
+impl<M, C> Points for WithColors<M, C>
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        self.mesh.points()
+    }
+}
+
+impl<M, T, S> Points for WithTexCoords<M, T, S>
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        self.mesh.points()
+    }
+}
+
+impl<M, N> Points for WithNormals<M, N>
+where
+    M: Points,
+{
+    type Scalar = M::Scalar;
+    type Point = M::Point;
+    type Points = M::Points;
+    fn points(&self) -> &Self::Points {
+        self.mesh.points()
+    }
+}
+
+// **Indices** implementations.
+
+impl<M, I> Indices for WithIndices<M, I>
+where
+    I: Channel<Element = usize>,
+{
+    type Indices = I;
+    fn indices(&self) -> &Self::Indices {
+        &self.indices
+    }
+}
+
+impl<'a, M> Indices for &'a M
+where
+    M: Indices,
+{
+    type Indices = M::Indices;
+    fn indices(&self) -> &Self::Indices {
+        (**self).indices()
+    }
+}
+
+impl<'a, M> Indices for &'a mut M
+where
+    M: Indices,
+{
+    type Indices = M::Indices;
+    fn indices(&self) -> &Self::Indices {
+        (**self).indices()
+    }
+}
+
+impl<M, C> Indices for WithColors<M, C>
+where
+    M: Indices,
+{
+    type Indices = M::Indices;
+    fn indices(&self) -> &Self::Indices {
+        self.mesh.indices()
+    }
+}
+
+impl<M, T, S> Indices for WithTexCoords<M, T, S>
+where
+    M: Indices,
+{
+    type Indices = M::Indices;
+    fn indices(&self) -> &Self::Indices {
+        self.mesh.indices()
+    }
+}
+
+impl<M, N> Indices for WithNormals<M, N>
+where
+    M: Indices,
+{
+    type Indices = M::Indices;
+    fn indices(&self) -> &Self::Indices {
+        self.mesh.indices()
+    }
+}
+
+// **Colors** implementations.
+
+impl<M, C> Colors for WithColors<M, C>
+where
+    C: Channel,
+{
+    type Color = C::Element;
+    type Colors = C;
+    fn colors(&self) -> &Self::Colors {
+        &self.colors
+    }
+}
+
+impl<'a, M> Colors for &'a M
+where
+    M: Colors,
+{
+    type Color = M::Color;
+    type Colors = M::Colors;
+    fn colors(&self) -> &Self::Colors {
+        (**self).colors()
+    }
+}
+
+impl<'a, M> Colors for &'a mut M
+where
+    M: Colors,
+{
+    type Color = M::Color;
+    type Colors = M::Colors;
+    fn colors(&self) -> &Self::Colors {
+        (**self).colors()
+    }
+}
+
+impl<M, I> Colors for WithIndices<M, I>
+where
+    M: Colors,
+{
+    type Color = M::Color;
+    type Colors = M::Colors;
+    fn colors(&self) -> &Self::Colors {
+        self.mesh.colors()
+    }
+}
+
+impl<M, T, S> Colors for WithTexCoords<M, T, S>
+where
+    M: Colors,
+{
+    type Color = M::Color;
+    type Colors = M::Colors;
+    fn colors(&self) -> &Self::Colors {
+        self.mesh.colors()
+    }
+}
+
+impl<M, N> Colors for WithNormals<M, N>
+where
+    M: Colors,
+{
+    type Color = M::Color;
+    type Colors = M::Colors;
+    fn colors(&self) -> &Self::Colors {
+        self.mesh.colors()
+    }
+}
+
+// **TexCoords** implementations.
+
+impl<M, T, S> TexCoords for WithTexCoords<M, T, S>
+where
+    T: Channel<Element = Point2<S>>,
+    S: BaseFloat,
+{
+    type TexCoordScalar = S;
+    type TexCoords = T;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        &self.tex_coords
+    }
+}
+
+impl<'a, M> TexCoords for &'a M
+where
+    M: TexCoords,
+{
+    type TexCoordScalar = M::TexCoordScalar;
+    type TexCoords = M::TexCoords;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        (**self).tex_coords()
+    }
+}
+
+impl<'a, M> TexCoords for &'a mut M
+where
+    M: TexCoords,
+{
+    type TexCoordScalar = M::TexCoordScalar;
+    type TexCoords = M::TexCoords;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        (**self).tex_coords()
+    }
+}
+
+impl<M, I> TexCoords for WithIndices<M, I>
+where
+    M: TexCoords,
+{
+    type TexCoordScalar = M::TexCoordScalar;
+    type TexCoords = M::TexCoords;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        self.mesh.tex_coords()
+    }
+}
+
+impl<M, C> TexCoords for WithColors<M, C>
+where
+    M: TexCoords,
+{
+    type TexCoordScalar = M::TexCoordScalar;
+    type TexCoords = M::TexCoords;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        self.mesh.tex_coords()
+    }
+}
+
+impl<M, N> TexCoords for WithNormals<M, N>
+where
+    M: TexCoords,
+{
+    type TexCoordScalar = M::TexCoordScalar;
+    type TexCoords = M::TexCoords;
+    fn tex_coords(&self) -> &Self::TexCoords {
+        self.mesh.tex_coords()
+    }
+}
+
+// **Normals** implementations.
+
+impl<M, N> Normals for WithNormals<M, N>
+where
+    M: Points,
+    M::Point: EuclideanSpace,
+    N: Channel<Element = <M::Point as EuclideanSpace>::Diff>,
+{
+    type Normals = N;
+    fn normals(&self) -> &Self::Normals {
+        &self.normals
+    }
+}
+
+impl<'a, M> Normals for &'a M
+where
+    M: Normals,
+    M::Point: EuclideanSpace,
+{
+    type Normals = M::Normals;
+    fn normals(&self) -> &Self::Normals {
+        (**self).normals()
+    }
+}
+
+impl<'a, M> Normals for &'a mut M
+where
+    M: Normals,
+    M::Point: EuclideanSpace,
+{
+    type Normals = M::Normals;
+    fn normals(&self) -> &Self::Normals {
+        (**self).normals()
+    }
+}
+
+impl<M, I> Normals for WithIndices<M, I>
+where
+    M: Normals,
+    M::Point: EuclideanSpace,
+{
+    type Normals = M::Normals;
+    fn normals(&self) -> &Self::Normals {
+        self.mesh.normals()
+    }
+}
+
+impl<M, C> Normals for WithColors<M, C>
+where
+    M: Normals,
+    M::Point: EuclideanSpace,
+{
+    type Normals = M::Normals;
+    fn normals(&self) -> &Self::Normals {
+        self.mesh.normals()
+    }
+}
+
+impl<M, T, S> Normals for WithTexCoords<M, T, S>
+where
+    M: Normals,
+    M::Point: EuclideanSpace,
+{
+    type Normals = M::Normals;
+    fn normals(&self) -> &Self::Normals {
+        self.mesh.normals()
+    }
+}
+
+// Deref implementations for the mesh adaptor types to their inner mesh.
+
+impl<M, I> Deref for WithIndices<M, I> {
+    type Target = M;
+    fn deref(&self) -> &Self::Target {
+        &self.mesh
+    }
+}
+
+impl<M, I> DerefMut for WithIndices<M, I> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mesh
+    }
+}
+
+impl<M, C> Deref for WithColors<M, C> {
+    type Target = M;
+    fn deref(&self) -> &Self::Target {
+        &self.mesh
+    }
+}
+
+impl<M, C> DerefMut for WithColors<M, C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mesh
+    }
+}
+
+impl<M, T, S> Deref for WithTexCoords<M, T, S> {
+    type Target = M;
+    fn deref(&self) -> &Self::Target {
+        &self.mesh
+    }
+}
+
+impl<M, T, S> DerefMut for WithTexCoords<M, T, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mesh
+    }
+}
+
+impl<M, N> Deref for WithNormals<M, N> {
+    type Target = M;
+    fn deref(&self) -> &Self::Target {
+        &self.mesh
+    }
+}
+
+impl<M, N> DerefMut for WithNormals<M, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mesh
+    }
+}
+
+// Mesh constructors.
+
+/// Create a simple base mesh from the given channel of vertex points.
+pub fn from_points<P>(points: P) -> MeshPoints<P>
+where
+    P: Channel,
+    P::Element: geom::Vertex,
+{
+    MeshPoints { points }
+}
+
+/// Combine the given mesh with the given channel of vertex indices.
+pub fn with_indices<M, I>(mesh: M, indices: I) -> WithIndices<M, I>
+where
+    M: GetVertex,
+    I: Channel<Element = usize>,
+{
+    WithIndices { mesh, indices }
+}
+
+/// Combine the given mesh with the given channel of vertex colors.
+pub fn with_colors<M, C>(mesh: M, colors: C) -> WithColors<M, C>
+where
+    C: Channel,
+{
+    WithColors { mesh, colors }
+}
+
+/// Combine the given mesh with the given channel of vertex texture coordinates.
+pub fn with_tex_coords<M, T, S>(mesh: M, tex_coords: T) -> WithTexCoords<M, T, S>
+where
+    T: Channel<Element = Point2<S>>,
+    S: BaseFloat,
+{
+    let _tex_coord_scalar = PhantomData;
+    WithTexCoords { mesh, tex_coords, _tex_coord_scalar }
+}
+
+/// Combine the given mesh with the given **Normals** channel.
+pub fn with_normals<M, N>(mesh: M, normals: N) -> WithNormals<M, N>
+where
+    M: Points,
+    M::Point: EuclideanSpace,
+    N: Channel<Element = <M::Point as EuclideanSpace>::Diff>,
+{
+    WithNormals { mesh, normals }
+}
+
+// Mesh iterators.
+
+/// An iterator yielding the raw vertices (with combined channels) of a mesh.
+///
+/// Requires that the mesh implements **GetVertex**.
+///
+/// Returns `None` when the inner mesh first returns `None` for a call to **GetVertex::get_vertex**.
+#[derive(Clone, Debug)]
+pub struct RawVertices<M> {
+    index: usize,
+    mesh: M,
+}
+
+/// An iterator yielding vertices in the order specified via the mesh's **Indices** channel.
+///
+/// Requires that the mesh implements **Indices** and **GetVertex**.
+///
+/// Returns `None` when a vertex has been yielded for every index in the **Indices** channel.
+///
+/// **Panics** if the **Indices** channel produces an index that is out of bounds of the mesh's
+/// vertices.
+#[derive(Clone, Debug)]
+pub struct Vertices<M> {
+    index: usize,
+    mesh: M,
+}
+
+/// An iterator yielding triangles in the order specified via the mesh's **Indices** channel.
+///
+/// Requires that the mesh implements **Indices** and **GetVertex**.
+///
+/// **Panics** if the **Indices** channel produces an index that is out of bounds of the mesh's
+pub type Triangles<M> = geom::tri::IterFromVertices<Vertices<M>>;
+
+/// An iterator yielding the raw vertices (with combined channels) of a mesh.
+///
+/// Requires that the inner mesh implements **GetVertex**.
+///
+/// Returns `None` when the inner mesh first returns `None` for a call to **GetVertex::get_vertex**.
+pub fn raw_vertices<M>(mesh: M) -> RawVertices<M>
+where
+    M: GetVertex,
+{
+    let index = 0;
+    RawVertices { index, mesh }
+}
+
+/// Produce an iterator yielding vertices in the order specified via the mesh's **Indices**
+/// channel.
+///
+/// Requires that the mesh implements **Indices** and **GetVertex**.
+///
+/// Returns `None` when a vertex has been yielded for every index in the **Indices** channel.
+///
+/// **Panics** if the **Indices** channel produces an index that is out of bounds of the mesh's
+/// vertices.
+pub fn vertices<M>(mesh: M) -> Vertices<M>
+where
+    M: Indices + GetVertex,
+{
+    let index = 0;
+    Vertices { index, mesh }
+}
+
+/// Produce an iterator yielding triangles for every three vertices yielded in the order specified
+/// via the mesh's **Indices** channel.
+///
+/// Requires that the mesh implements **Indices** and **GetVertex**.
+///
+/// Returns `None` when there are no longer enough vertex indices to produce a triangle.
+///
+/// **Panics** if the **Indices** channel produces an index that is out of bounds of the mesh's
+/// vertices.
+pub fn triangles<M>(mesh: M) -> Triangles<M>
+where
+    M: Indices + GetVertex,
+{
+    geom::tri::iter_from_vertices(vertices(mesh))
+}
+
+// The error message produced when the `Vertices` iterator panics due to an out of bound index.
+const NO_VERTEX_FOR_INDEX: &'static str =
+    "no vertex for the index produced by the mesh's indices channel";
+
+impl<M> Iterator for RawVertices<M>
+where
+    M: GetVertex,
+{
+    type Item = M::Vertex;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(vertex) = self.mesh.get_vertex(self.index) {
+            self.index += 1;
+            return Some(vertex);
+        }
+        None
+    }
+}
+
+impl<M> Iterator for Vertices<M>
+where
+    M: Indices + GetVertex,
+{
+    type Item = M::Vertex;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(&index) = self.mesh.indices().channel().get(self.index) {
+            self.index += 1;
+            let vertex = self.mesh.get_vertex(index).expect(NO_VERTEX_FOR_INDEX);
+            return Some(vertex);
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<M> DoubleEndedIterator for Vertices<M>
+where
+    M: Indices + GetVertex,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let next_index = self.index + 1;
+        let indices = self.mesh.indices().channel();
+        if let Some(&index) = indices.get(indices.len() - next_index) {
+            self.index = next_index;
+            let vertex = self.mesh.get_vertex(index).expect(NO_VERTEX_FOR_INDEX);
+            return Some(vertex);
+        }
+        None
+    }
+}
+
+impl<M> ExactSizeIterator for Vertices<M>
+where
+    M: Indices + GetVertex,
+{
+    fn len(&self) -> usize {
+        self.mesh.indices().channel().len() - self.index
+    }
+}

--- a/src/mesh/vertex.rs
+++ b/src/mesh/vertex.rs
@@ -1,0 +1,153 @@
+//! Vertex types yielded by the mesh adaptors and their implementations.
+
+use geom;
+use math::{Point2, Point3};
+use std::ops::{Deref, DerefMut};
+
+/// A vertex with a specified color.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithColor<V, C> {
+    pub vertex: V,
+    pub color: C,
+}
+
+/// A vertex with some specified texture coordinates.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithTexCoords<V, T> {
+    pub vertex: V,
+    pub tex_coords: T,
+}
+
+/// A vertex with its normal vector.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct WithNormal<V, N> {
+    pub vertex: V,
+    pub normal: N,
+}
+
+// Deref implementations for each vertex adaptor to their inner vertex type.
+
+impl<V, C> Deref for WithColor<V, C> {
+    type Target = V;
+    fn deref(&self) -> &Self::Target {
+        &self.vertex
+    }
+}
+
+impl<V, C> DerefMut for WithColor<V, C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vertex
+    }
+}
+
+impl<V, T> Deref for WithTexCoords<V, T> {
+    type Target = V;
+    fn deref(&self) -> &Self::Target {
+        &self.vertex
+    }
+}
+
+impl<V, T> DerefMut for WithTexCoords<V, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vertex
+    }
+}
+
+impl<V, N> Deref for WithNormal<V, N> {
+    type Target = V;
+    fn deref(&self) -> &Self::Target {
+        &self.vertex
+    }
+}
+
+impl<V, N> DerefMut for WithNormal<V, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.vertex
+    }
+}
+
+// Geometry vertex implementations.
+
+impl<V, C> geom::Vertex for WithColor<V, C>
+where
+    V: geom::Vertex,
+    C: Clone + Copy + PartialEq,
+{
+    type Scalar = V::Scalar;
+}
+
+impl<V, T> geom::Vertex for WithTexCoords<V, T>
+where
+    V: geom::Vertex,
+    T: Clone + Copy + PartialEq,
+{
+    type Scalar = V::Scalar;
+}
+
+impl<V, N> geom::Vertex for WithNormal<V, N>
+where
+    V: geom::Vertex,
+    N: Clone + Copy + PartialEq,
+{
+    type Scalar = V::Scalar;
+}
+
+impl<V, C> geom::Vertex2d for WithColor<V, C>
+where
+    V: geom::Vertex2d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point2(self) -> Point2<Self::Scalar> {
+        self.vertex.point2()
+    }
+}
+
+impl<V, T> geom::Vertex2d for WithTexCoords<V, T>
+where
+    V: geom::Vertex2d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point2(self) -> Point2<Self::Scalar> {
+        self.vertex.point2()
+    }
+}
+
+impl<V, N> geom::Vertex2d for WithNormal<V, N>
+where
+    V: geom::Vertex2d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point2(self) -> Point2<Self::Scalar> {
+        self.vertex.point2()
+    }
+}
+
+impl<V, C> geom::Vertex3d for WithColor<V, C>
+where
+    V: geom::Vertex3d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point3(self) -> Point3<Self::Scalar> {
+        self.vertex.point3()
+    }
+}
+
+impl<V, T> geom::Vertex3d for WithTexCoords<V, T>
+where
+    V: geom::Vertex3d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point3(self) -> Point3<Self::Scalar> {
+        self.vertex.point3()
+    }
+}
+
+impl<V, N> geom::Vertex3d for WithNormal<V, N>
+where
+    V: geom::Vertex3d,
+    Self: geom::Vertex<Scalar = V::Scalar>,
+{
+    fn point3(self) -> Point3<Self::Scalar> {
+        self.vertex.point3()
+    }
+}

--- a/src/mesh/vertex.rs
+++ b/src/mesh/vertex.rs
@@ -1,7 +1,8 @@
 //! Vertex types yielded by the mesh adaptors and their implementations.
 
 use geom;
-use math::{Point2, Point3};
+use geom::graph::node::{self, ApplyTransform};
+use math::{BaseFloat, Point2, Point3};
 use std::ops::{Deref, DerefMut};
 
 /// A vertex with a specified color.
@@ -23,6 +24,46 @@ pub struct WithTexCoords<V, T> {
 pub struct WithNormal<V, N> {
     pub vertex: V,
     pub normal: N,
+}
+
+// Node Transform application implementations.
+
+impl<S, V, C> ApplyTransform<S> for WithColor<V, C>
+where
+    V: ApplyTransform<S>,
+    S: BaseFloat,
+{
+    fn apply_transform(self, transform: &node::Transform<S>) -> Self {
+        let WithColor { mut vertex, color } = self;
+        vertex = vertex.apply_transform(transform);
+        WithColor { vertex, color }
+    }
+}
+
+impl<S, V, T> ApplyTransform<S> for WithTexCoords<V, T>
+where
+    V: ApplyTransform<S>,
+    S: BaseFloat,
+{
+    fn apply_transform(self, transform: &node::Transform<S>) -> Self {
+        let WithTexCoords { mut vertex, tex_coords } = self;
+        vertex = vertex.apply_transform(transform);
+        WithTexCoords { vertex, tex_coords }
+    }
+}
+
+impl<S, V, N> ApplyTransform<S> for WithNormal<V, N>
+where
+    V: ApplyTransform<S>,
+    S: BaseFloat,
+{
+    fn apply_transform(self, _transform: &node::Transform<S>) -> Self {
+        //let WithNormal { mut vertex, mut normal } = self;
+        //vertex = vertex.apply_transform(transform);
+        // TODO: Apply transform to the `normal`.
+        unimplemented!();
+        //WithNormal { vertex, normal }
+    }
 }
 
 // Deref implementations for each vertex adaptor to their inner vertex type.

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ pub use self::window::Window;
 
 /// Tracked state related to the focused window.
 pub mod window {
+    use geom;
     use window;
     use math::Vector2;
 
@@ -33,6 +34,25 @@ pub mod window {
                 height: 0.0,
                 hidpi_factor: 1.0,
             }
+        }
+
+        /// Get the range along the *x* axis occupied by the window.
+        pub fn x_range(&self) -> geom::Range<f64> {
+            let half_w = self.width * 0.5;
+            geom::Range { start: -half_w, end: half_w }
+        }
+
+        /// Get the range along the *y* axis occupied by the window.
+        pub fn y_range(&self) -> geom::Range<f64> {
+            let half_h = self.height * 0.5;
+            geom::Range { start: -half_h, end: half_h }
+        }
+
+        /// Get the x coordinate for the left edge of the window.
+        pub fn rect(&self) -> geom::Rect<f64> {
+            let x = self.x_range();
+            let y = self.y_range();
+            geom::Rect { x, y }
         }
 
         /// Return the `width` and `height` as a `Vector2`.


### PR DESCRIPTION
## mesh

Includes a `mesh::channel` module declaring `Channel` types that may be
used as a channel within a mesh.

Adds constructors and implementations for `WithIndices` `WithColors`,
`WithTexCoords` and `WithNormals` mesh adaptors.

Provides functions for producing `raw_vertices`, `vertices` and
`triangles` from any mesh type that implements `GetVertex` and `Indices`
respectively.

This `Mesh` type will form the foundation for the `draw::Mesh`
implementation - a much simpler API around a general-use mesh.

## graph

Strip back `geom::Graph` so that it does not own any vertices.

Instead, the graph can be used purely for composing layout and
generating transforms for each conceptual node.

TransformedVertices/Triangles walkers and iterators are still provided
but instead require that the user provides a function mapping from nodes
to their respective vertices, rather than having all vertices packed
within the graph itself. This allows for using a graph to describe the
layout of geometry whose vertices might be contained entirely within
some mesh or other form of ownership.

## draw

Currently only supports ellipses, but the rest of the geometry types
should be easy to add.

Also provides a background method for a simpler way of clearing the gl
frame.

Provides methods for yielding raw vertices, indices and transformed
vertices. Also provides a backend for drawing directly to a glium surface.

A `app::Draw` type has been added that wraps the `App`'s own **Draw**
instance which is re-used between frames for efficiency.