### PR TITLE
Add `Range::lerp` method. Add missing `Rect` constructors. Add many new items to prelude.

### DIFF
--- a/src/geom/range.rs
+++ b/src/geom/range.rs
@@ -163,6 +163,22 @@ where
         math::map_range(value, self.start, self.end, other.start, other.end)
     }
 
+    /// Interpolates the **Range** using the given `weight`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use nannou::geom::Range;
+    ///
+    /// let r = Range::new(-5.0, 5.0);
+    /// assert_eq!(r.lerp(0.0), -5.0);
+    /// assert_eq!(r.lerp(1.0), 5.0);
+    /// assert_eq!(r.lerp(0.5), 0.0);
+    /// ```
+    pub fn lerp(&self, amount: S) -> S {
+        self.start + ((self.end - self.start) * amount)
+    }
+
     /// Shift the `Range` start and end points by a given scalar.
     ///
     /// # Examples

--- a/src/geom/rect.rs
+++ b/src/geom/rect.rs
@@ -117,10 +117,20 @@ where
         }
     }
 
+    /// Construct a Rect from the given `x` `y` coordinates and `w` `h` dimensions.
+    pub fn from_x_y_w_h(x: S, y: S, w: S, h: S) -> Self {
+        Rect::from_xy_wh(Point2 { x, y }, Vector2 { x: w, y: h })
+    }
+
     /// Construct a Rect at origin with the given dimensions.
     pub fn from_wh(wh: Vector2<S>) -> Self {
         let p = Point2 { x: S::zero(), y: S::zero() };
         Self::from_xy_wh(p, wh)
+    }
+
+    /// Construct a Rect at origin with the given width and height.
+    pub fn from_w_h(w: S, h: S) -> Self {
+        Self::from_wh(Vector2 { x: w, y: h })
     }
 
     /// Construct a Rect from the coordinates of two points.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub extern crate daggy;
 pub extern crate find_folder;
 #[macro_use] pub extern crate glium;
-pub extern crate rand;
 
 use event::LoopEvent;
 use glium::glutin;
@@ -29,6 +28,7 @@ pub mod math;
 pub mod mesh;
 pub mod osc;
 pub mod prelude;
+pub mod rand;
 pub mod state;
 pub mod ui;
 pub mod window;

--- a/src/math.rs
+++ b/src/math.rs
@@ -3,14 +3,17 @@ pub use self::cgmath::*;
 pub use self::cgmath::num_traits::{NumCast, One};
 use std::ops::Add;
 
+/// Shorthand constructor for a `Point1`.
 pub fn pt1<S>(x: S) -> Point1<S> {
     Point1 { x }
 }
 
+/// Shorthand constructor for a `Point2`.
 pub fn pt2<S>(x: S, y: S) -> Point2<S> {
     Point2 { x, y }
 }
 
+/// Shorthand constructor for a `Point3`.
 pub fn pt3<S>(x: S, y: S, z: S) -> Point3<S> {
     Point3 { x, y, z }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,3 +8,14 @@ pub use frame::Frame;
 pub use math::{Point2, Point3, Vector2, Vector3, vec1, vec2, vec3, vec4, pt1, pt2, pt3};
 pub use math::prelude::*;
 pub use window::Id as WindowId;
+
+// The following constants have "regular" names for the `DefaultScalar` type and type suffixes for
+// other types. If the `DefaultScalar` changes, these should probably change too.
+
+pub use std::f32::consts::PI as PI;
+pub use std::f64::consts::PI as PI_F64;
+
+/// Two times PI.
+pub const TAU: f32 = PI * 2.0;
+/// Two times PI.
+pub const TAU_F64: f64 = PI_F64 * 2.0;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,12 +1,17 @@
 //! A collection of commonly used items that we recommend importing for ease of use.
 
 pub use app::{App, LoopMode};
+pub use color::{Hsl, Hsla, Hsv, Hsva, Rgb, Rgba};
 pub use color::named::*;
 pub use event::SimpleWindowEvent::*;
 pub use event::{Event, Key};
 pub use frame::Frame;
-pub use math::{Point2, Point3, Vector2, Vector3, vec1, vec2, vec3, vec4, pt1, pt2, pt3};
+pub use geom::{self, Rect, Cuboid};
+pub use math::{clamp, map_range, pt1, pt2, pt3, vec1, vec2, vec3, vec4, Point2, Point3, Vector2,
+               Vector3};
 pub use math::prelude::*;
+pub use math::num_traits::*;
+pub use rand::{random, random_f32, random_f64, random_range};
 pub use window::Id as WindowId;
 
 // The following constants have "regular" names for the `DefaultScalar` type and type suffixes for

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,0 +1,31 @@
+pub extern crate rand;
+
+pub use self::rand::*;
+
+/// A wrapper function around the `random` function that avoids the need for specifying a type in
+/// the case that it cannot be inferred. The primary purpose for this is to simplify the random API
+/// for new rust users.
+pub fn random_f32() -> f32 {
+    random()
+}
+
+/// A wrapper function around the `random` function that avoids the need for specifying a type in
+/// the case that it cannot be inferred. The primary purpose for this is to simplify the random API
+/// for new rust users.
+pub fn random_f64() -> f64 {
+    random()
+}
+
+/// A function for generating a random value within the given range.
+///
+/// The generated value may be within the range [min, max). That is, the result is inclusive of
+/// `min`, but will never be `max`.
+///
+/// This calls `rand::thread_rng().gen_range(min, max)` internally, in turn using the thread-local
+/// default random number generator.
+pub fn random_range<T>(min: T, max: T) -> T
+where
+    T: PartialOrd + distributions::range::SampleRange,
+{
+    rand::thread_rng().gen_range(min, max)
+}


### PR DESCRIPTION
Also adds a doc example of how to use `Range::lerp` (see code below).

Closes #74.
Closes #73.
Closes #80.
Closes #82.
Closes #88.
Closes #91.