### PR TITLE
Change OSC default binding address from `127.0.0.1` to `0.0.0.0`

### DIFF
--- a/src/osc/mod.rs
+++ b/src/osc/mod.rs
@@ -95,7 +95,7 @@ impl Packet {
 
 /// The default local IP address.
 pub fn default_ipv4_addr() -> Ipv4Addr {
-    Ipv4Addr::new(127, 0, 0, 1)
+    Ipv4Addr::new(0, 0, 0, 0)
 }
 
 /// A simple wrapper around the most commonly used `Receiver` constructor.


### PR DESCRIPTION
`127.0.0.1` is a particularly poor default for osc senders as they're
only able to send to that same port. `0.0.0.0` binds to all network
interfaces (rather than just the loopback interface) and so is a
reasonable default that should "just work" in most cases. It seems that
`osc.js` also does this and it seems that Max/MSP does too (though I'm
not certain).