### PR TITLE
Add fullscreen toggle keyboard shortcuts.

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -593,4 +593,18 @@ impl Window {
     pub fn inner_glium_display(&self) -> &glium::Display {
         &self.display
     }
+
+    /// Attempts to determine whether or not the window is currently fullscreen.
+    ///
+    /// TODO: This currently relies on comparing `outer_size_pixels` to the dimensions of the
+    /// `current_monitor`, which may not be exactly accurate on some platforms or even conceptually
+    /// correct in the case that a title bar is included or something. This should probably be a
+    /// method upstream within the `winit` crate itself. Alternatively we could attempt to manually
+    /// track whether or not the window is fullscreen ourselves, however this could get quite
+    /// complicated quite quickly.
+    pub fn is_fullscreen(&self) -> bool {
+        let (w, h) = self.outer_size_pixels();
+        let (mw, mh) = self.current_monitor().get_dimensions();
+        w == mw && h == mh
+    }
 }


### PR DESCRIPTION
This enables fullscreen shortcuts by default, however they can easily be
disabled / enabled via the `App::set_fullscreen_on_shortcut` method.

The fullscreen shortcuts are currently as follows:

- Linux: `F11`
- MacOS: `CMD + f`
- Windows: `WIN + f`

Currently this uses a custom `is_fullscreen` method to perform the
toggling, however this should probably be provided by winit upstream.

Currently only tested on Linux + Gnome.