### PR TITLE
Remove `app.window.*` fields in favour of `app.window_rect()` method

### DIFF
--- a/examples/simple_draw.rs
+++ b/examples/simple_draw.rs
@@ -14,7 +14,7 @@ fn view(app: &App, frame: Frame) -> Frame {
     draw.background().color(BLUE);
 
     // Draw a purple triangle in the top left half of the window.
-    let win = app.window.rect();
+    let win = app.window_rect();
     draw.tri()
         .points(win.bottom_left(), win.top_left(), win.top_right())
         .color(DARK_PURPLE);
@@ -23,7 +23,7 @@ fn view(app: &App, frame: Frame) -> Frame {
     let t = app.duration.since_start.secs() as f32;
     draw.ellipse()
         .x_y(app.mouse.x * t.cos(), app.mouse.y)
-        .radius(app.window.width * 0.125 * t.sin())
+        .radius(win.w() * 0.125 * t.sin())
         .color(RED);
 
     // Draw a line!

--- a/src/app.rs
+++ b/src/app.rs
@@ -279,6 +279,16 @@ impl App {
         }
     }
 
+    /// Return the **Rect** for the currently focused window.
+    ///
+    /// The **Rect** coords are described in "points" (pixels divided by the hidpi factor).
+    ///
+    /// **Panics** if there are no windows or if no window is in focus.
+    pub fn window_rect(&self) -> geom::Rect<DrawScalar> {
+        let (w, h) = self.main_window().inner_size_points();
+        geom::Rect::from_w_h(w as _, h as _)
+    }
+
     /// A reference to the window currently in focus.
     ///
     /// **Panics** if their are no windows open in the **App**.

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,69 +7,28 @@ pub use self::window::Window;
 pub mod window {
     use geom;
     use window;
-    use math::{BaseFloat, Vector2};
 
     /// The default scalar value used for window positioning and sizing.
     pub type DefaultScalar = geom::DefaultScalar;
 
     /// State of the window in focus.
     #[derive(Copy, Clone, Debug, PartialEq)]
-    pub struct Window<S = DefaultScalar> {
+    pub struct Window {
         /// ID of the window currently in focus.
         pub id: Option<window::Id>,
-        /// The width of the focused window agnostic of DPI.
-        ///
-        /// This is equal to the pixel width divided by the hidpi_factor.
-        pub width: S,
-        /// The height of the focused window agnostic of DPI.
-        ///
-        /// This is equal to the pixel height divided by the hidpi_factor.
-        pub height: S,
-        /// The high "dots-per-inch" multiplier that describes the density of the screens pixels.
-        pub hidpi_factor: S,
     }
 
-    impl<S> Window<S>
-    where
-        S: BaseFloat,
-    {
+    impl Window {
         /// Initialise the window state.
         pub fn new() -> Self {
             Window {
                 id: None,
-                width: S::zero(),
-                height: S::zero(),
-                hidpi_factor: S::one(),
             }
-        }
-
-        /// Get the range along the *x* axis occupied by the window.
-        pub fn x_range(&self) -> geom::Range<S> {
-            let half_w = self.width / (S::one() + S::one());
-            geom::Range { start: -half_w, end: half_w }
-        }
-
-        /// Get the range along the *y* axis occupied by the window.
-        pub fn y_range(&self) -> geom::Range<S> {
-            let half_h = self.height / (S::one() + S::one());
-            geom::Range { start: -half_h, end: half_h }
-        }
-
-        /// Get the x coordinate for the left edge of the window.
-        pub fn rect(&self) -> geom::Rect<S> {
-            let x = self.x_range();
-            let y = self.y_range();
-            geom::Rect { x, y }
         }
 
         /// Expects that there will be a `window::Id` (the common case) and **panic!**s otherwise.
         pub fn id(&self) -> window::Id {
             self.id.unwrap()
-        }
-
-        /// Return the `width` and `height` as a `Vector2`.
-        pub fn size(&self) -> Vector2<S> {
-            Vector2 { x: self.width, y: self.height }
         }
     }
 }


### PR DESCRIPTION
Please see the changes to the `simple_draw.rs` example to see how to
update your code for these changes.

Closes #71.